### PR TITLE
Fill and submit a Lever application

### DIFF
--- a/docs/superpowers/plans/2026-09-09-lever-fill-and-submit.md
+++ b/docs/superpowers/plans/2026-09-09-lever-fill-and-submit.md
@@ -1,0 +1,613 @@
+# Lever Fill and Submit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let auto-apply fill and submit a Lever application, the second provider after Greenhouse.
+
+**Architecture:** A small per-provider registry replaces the four places the provider is currently hard-coded — the form's element id, the submit button's selector, and how a field is identified and selected (`id` on Greenhouse, `name` on Lever). Everything else in the pipeline is already provider-agnostic and does not change.
+
+**Tech Stack:** Go 1.26, chromedp (headless Chrome), `golang.org/x/net/html`.
+
+## Global Constraints
+
+- **English only** in all code, comments, identifiers, docs and commit messages.
+- Before committing any `*.go`: `gofmt -w` those paths, then `go vet ./...` and `go test ./...`. Before pushing: `go vet -tags=integration ./...`.
+- Pre-commit hooks (gofmt, gitleaks, doc-links, go vet, golangci-lint) run automatically. If one fails, fix the cause — never `--no-verify`.
+- The Go build cache is shared and has been observed corrupting mid-build (`no such file or directory` under `~/Library/Caches/go-build`). On that, `export GOCACHE=/tmp/gocache-lv` and retry.
+- Use `git commit -F <file>` for multi-line messages, never `-m` with backticks.
+- **A submit click is irreversible.** Nothing in this plan may make one more likely on a page nobody measured. When a value is unknown, park.
+- **Fixtures must be reduced from real captured DOM**, never hand-written to match the code. A hand-written fixture passed while the live page failed, twice, in this package this week.
+- `internal/api/atsapply` is layer 8 (`api`); it may import `dict` and `application` but nothing may import it back.
+
+---
+
+## File Structure
+
+**Create:**
+- `internal/api/atsapply/layout.go` — the provider registry: the `formLayout` type, the `addressing` values, the table, and its lookup. One responsibility, no I/O.
+- `internal/api/atsapply/layout_test.go`
+- `internal/api/atsapply/leverform_test.go` — the reduced real Lever DOM fixture and the scan/selector tests over it.
+
+**Modify:**
+- `internal/api/atsapply/domscan.go` — `ScanGreenhouseForm` becomes layout-driven; `scanControls` honours the addressing.
+- `internal/api/atsapply/fill.go` — `fieldSelector` and the submit click read the layout.
+- `internal/api/atsapply/client.go` — `fillProviders` gains `lever`; the `if provider == "greenhouse"` branch becomes a layout lookup.
+- `internal/api/atsapply/preview_client.go` — its own Greenhouse branch, same change.
+
+---
+
+### Task 1: The provider registry
+
+**Files:**
+- Create: `internal/api/atsapply/layout.go`
+- Create: `internal/api/atsapply/layout_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `type addressing int` with `byID` and `byName`
+  - `type formLayout struct { formSelector, submitSelector string; addressBy addressing }`
+  - `func layoutFor(provider string) (formLayout, bool)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/api/atsapply/layout_test.go`:
+
+```go
+package atsapply
+
+import "testing"
+
+func TestLayoutFor_KnowsTheTwoProvidersWithAFillPath(t *testing.T) {
+	gh, ok := layoutFor("greenhouse")
+	if !ok {
+		t.Fatal("greenhouse has no layout")
+	}
+	if gh.formSelector != "application-form" || gh.submitSelector != "#submit_app" || gh.addressBy != byID {
+		t.Errorf("greenhouse layout = %+v, want the ids measured on its own pages", gh)
+	}
+
+	lv, ok := layoutFor("lever")
+	if !ok {
+		t.Fatal("lever has no layout")
+	}
+	// Measured on jobs.lever.co/coderio/.../apply, 2026-09-09: the form carries the same
+	// id Greenhouse's does, the button a person clicks is #btn-submit, and the inputs
+	// carry no id at all — only name.
+	if lv.formSelector != "application-form" || lv.submitSelector != "#btn-submit" || lv.addressBy != byName {
+		t.Errorf("lever layout = %+v, want what was measured on a live posting", lv)
+	}
+}
+
+func TestLayoutFor_RefusesAProviderWithNoFillPath(t *testing.T) {
+	for _, provider := range []string{"ashby", "workable", "recruitee", ""} {
+		if _, ok := layoutFor(provider); ok {
+			t.Errorf("layoutFor(%q) returned a layout; no fill path exists for it", provider)
+		}
+	}
+}
+
+// The registry and fillProviders answer the same question and must not drift: a provider
+// Submit will try to fill, with no layout to fill it by, would reach a submit click with
+// selectors that match nothing.
+func TestLayoutFor_CoversEveryFillProvider(t *testing.T) {
+	for provider := range fillProviders {
+		if _, ok := layoutFor(provider); !ok {
+			t.Errorf("%q is in fillProviders but has no layout", provider)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/api/atsapply/ -run TestLayoutFor`
+Expected: FAIL to build — `layoutFor`, `formLayout`, `byID`, `byName` undefined.
+
+- [ ] **Step 3: Write the registry**
+
+Create `internal/api/atsapply/layout.go`:
+
+```go
+package atsapply
+
+// addressing is how a platform identifies a field on its own application form — which
+// attribute names it, and therefore which attribute selects it.
+//
+// It is ONE setting rather than two because the two must agree. If the scan identified a
+// field by one attribute and the fill selected it by another, every field would resolve
+// and then not be found on the page: a silent failure at the last step, after the model
+// spend and the candidate's approval.
+type addressing int
+
+const (
+	// byID identifies a field by its `id`. Greenhouse names every control.
+	byID addressing = iota
+	// byName identifies a field by its `name`. Lever's inputs carry no id at all —
+	// `<input type="text" data-qa="name-input" name="name" required>` — measured on
+	// jobs.lever.co/coderio/.../apply, 2026-09-09.
+	byName
+)
+
+// formLayout is what this package needs to know about one platform's application page.
+// Three values, each of which somebody read off a real posting.
+//
+// A table rather than heuristics, deliberately. Finding the form by "the one with the most
+// inputs", or the button by "the one that says Apply", is the class of guess this package
+// was burned by twice in one day: a captcha marker that fired on the mere WORD "recaptcha"
+// and parked every Greenhouse posting there is, and a per-provider captcha list that
+// decided what a page said before anyone loaded the page. A submit click cannot be taken
+// back, so what drives one is measured, not inferred.
+type formLayout struct {
+	// formSelector is the element id the application form renders under — the id itself,
+	// with no leading '#', because renderedHTML waits on it with chromedp.ByID and
+	// domscan finds it with findByID.
+	formSelector string
+	// submitSelector is the CSS selector for the button a PERSON clicks. On Lever that is
+	// `#btn-submit`, a type="button" whose own JS performs the invisible hCaptcha when the
+	// employer enabled one and then clicks the real hidden button. Nothing here needs to
+	// know that.
+	submitSelector string
+	// addressBy is how a field on this platform is named and selected.
+	addressBy addressing
+}
+
+// layouts is every provider this package can drive a browser against. A provider absent
+// here has no fill path, which Submit reports as not-implemented rather than attempting.
+var layouts = map[string]formLayout{
+	"greenhouse": {formSelector: "application-form", submitSelector: "#submit_app", addressBy: byID},
+	"lever":      {formSelector: "application-form", submitSelector: "#btn-submit", addressBy: byName},
+}
+
+// layoutFor returns the provider's layout, or false when this package cannot drive it.
+//
+// Both platforms happen to call the form `application-form` today. That is a coincidence
+// and is written out per-provider rather than shared, because the third platform will not
+// share it and a shared constant would have to be un-shared under time pressure.
+func layoutFor(provider string) (formLayout, bool) {
+	l, ok := layouts[provider]
+	return l, ok
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/api/atsapply/ -run TestLayoutFor -v`
+Expected: PASS — three tests. `TestLayoutFor_CoversEveryFillProvider` passes trivially for now (`fillProviders` still holds Greenhouse alone); Task 4 is what makes it load-bearing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/api/atsapply/
+go vet ./... && go test ./...
+git add internal/api/atsapply/layout.go internal/api/atsapply/layout_test.go
+git commit -F <a file containing a message explaining the registry and why it is measured values rather than heuristics>
+```
+
+---
+
+### Task 2: Scanning by the layout
+
+**Files:**
+- Modify: `internal/api/atsapply/domscan.go`
+- Create: `internal/api/atsapply/leverform_test.go`
+- Modify: `internal/api/atsapply/browser.go` (the `greenhouseFormReadySelector` constant's callers)
+
+**Interfaces:**
+- Consumes: `formLayout`, `byName`, `layoutFor` (Task 1).
+- Produces: `func ScanForm(pageHTML string, layout formLayout) ([]DOMField, error)` — replaces `ScanGreenhouseForm`. `DOMField.ID` carries the field's identifier under the layout's addressing.
+
+- [ ] **Step 1: Capture the fixture**
+
+The fixture must be reduced from the real DOM, not written to match the code. These are the controls a live Lever posting renders, captured on 2026-09-09 from `jobs.lever.co/coderio/6ce0e52b-e7bc-462f-ac9e-1d31c8c0e037/apply` — copy them verbatim into `internal/api/atsapply/leverform_test.go`:
+
+```go
+package atsapply
+
+import "testing"
+
+// Reduced from the live DOM of jobs.lever.co/coderio/6ce0e52b-.../apply, captured
+// 2026-09-09. Every attribute below is verbatim; only unrelated markup between the
+// controls was dropped.
+//
+// The point of the fixture is what Lever does NOT have: no input carries an `id`. Only
+// the location autocomplete does, and its id is not what the platform posts under.
+const leverFormHTML = `
+<html><body>
+<form id="application-form" enctype="multipart/form-data" method="POST">
+  <input id="resume-upload-input" name="resume" type="file">
+  <input type="text" data-qa="name-input" name="name" required="">
+  <input name="email" data-qa="email-input" type="email" required="">
+  <input type="text" data-qa="phone-input" name="phone" required="">
+  <input class="location-input" data-qa="location-input" id="location-input" type="text" maxlength="100" name="location">
+  <input type="text" name="org">
+  <input type="text" name="urls[LinkedIn]">
+  <input type="radio" name="cards[192519c4-2fbe-4575-9ab0-db6643cd5135][field0]" value="Menos de 1 año" required="required">
+  <input type="radio" name="cards[192519c4-2fbe-4575-9ab0-db6643cd5135][field0]" value="Entre 1 y 2 años" required="required">
+  <button id="hcaptchaSubmitBtn" type="submit" class="hidden"></button>
+  <button id="btn-submit" type="button" data-qa="btn-submit">Submit application</button>
+</form>
+</body></html>
+`
+
+// Under byName addressing a field's identity is its name, because that is the only thing
+// Lever's inputs carry — and it is what the platform posts under.
+func TestScanForm_IdentifiesLeverFieldsByName(t *testing.T) {
+	layout, _ := layoutFor("lever")
+
+	fields, err := ScanForm(leverFormHTML, layout)
+	if err != nil {
+		t.Fatalf("ScanForm: %v", err)
+	}
+
+	byIdent := map[string]DOMField{}
+	for _, f := range fields {
+		byIdent[f.ID] = f
+	}
+	for _, want := range []string{"name", "email", "phone", "location", "resume", "urls[LinkedIn]"} {
+		if _, ok := byIdent[want]; !ok {
+			t.Errorf("no field identified as %q; scanned %+v", want, fields)
+		}
+	}
+	if got := byIdent["resume"].Kind; got != "file" {
+		t.Errorf("resume kind = %q, want file", got)
+	}
+	// The location autocomplete has BOTH an id and a name, and they differ. The name is
+	// what Lever posts under, so byName must not quietly prefer the id.
+	if _, wrong := byIdent["location-input"]; wrong {
+		t.Error(`the location field was identified by its id ("location-input") rather than its name ("location")`)
+	}
+}
+
+// A Greenhouse posting must keep being identified by id — the change must not move the
+// provider that already worked.
+func TestScanForm_StillIdentifiesGreenhouseFieldsByID(t *testing.T) {
+	layout, _ := layoutFor("greenhouse")
+
+	fields, err := ScanForm(greenhouseFixtureHTML, layout)
+	if err != nil {
+		t.Fatalf("ScanForm: %v", err)
+	}
+	if len(fields) == 0 {
+		t.Fatal("no fields scanned from the vanilla Greenhouse fixture")
+	}
+	for _, f := range fields {
+		if f.ID == "" {
+			t.Errorf("a Greenhouse field came back with no identifier: %+v", f)
+		}
+	}
+}
+
+// An input a byName layout cannot address is dropped rather than given a synthetic key.
+// Under byID such a control gets one so two of them do not collide in the scan; under
+// byName that key would produce a field that resolves and then cannot be typed into —
+// the silent last-step failure the addressing setting exists to prevent.
+func TestScanForm_DropsANamelessFieldUnderByNameAddressing(t *testing.T) {
+	const html = `<html><body><form id="application-form">
+	  <input type="text" name="email">
+	  <input type="text" required="">
+	</form></body></html>`
+	layout, _ := layoutFor("lever")
+
+	fields, err := ScanForm(html, layout)
+	if err != nil {
+		t.Fatalf("ScanForm: %v", err)
+	}
+	if len(fields) != 1 || fields[0].ID != "email" {
+		t.Fatalf("scanned %+v, want only the addressable field", fields)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/api/atsapply/ -run TestScanForm`
+Expected: FAIL to build — `ScanForm` undefined.
+
+- [ ] **Step 3: Make the scan layout-driven**
+
+In `internal/api/atsapply/domscan.go`:
+
+Replace `ScanGreenhouseForm` with `ScanForm`, taking the layout:
+
+```go
+// ScanForm parses a rendered application page's form into its field inventory, per the
+// platform's own layout. Pure function over an HTML string — no browser, no network —
+// mirroring internal/ingest/applyform's own FromLever, which parses markup the same way.
+func ScanForm(pageHTML string, layout formLayout) ([]DOMField, error) {
+	doc, err := html.Parse(strings.NewReader(pageHTML))
+	if err != nil {
+		return nil, fmt.Errorf("parse page: %w", err)
+	}
+	form := findByID(doc, layout.formSelector)
+	if form == nil {
+		return nil, fmt.Errorf("no #%s on the page", layout.formSelector)
+	}
+	return scanControls(form, layout.addressBy), nil
+}
+```
+
+Thread `addressBy` through `scanControls`, `scanInput` and `scanSimple`. In each place a
+field's identity is decided, the rule is:
+
+```go
+// identify returns the identifier this layout addresses a control by, and whether the
+// control can be addressed at all.
+//
+// Under byName a control with no name is dropped: it can never be selected on the page,
+// so a field for it would resolve and then fail at the fill. Under byID the existing
+// synthetic-key fallback stands — it exists so two id-less controls do not collide in the
+// scan, and a Greenhouse control that lands there is still reported to the candidate as an
+// unmapped question rather than silently filled.
+func identify(id, name string, by addressing, order *[]string) (string, bool) {
+	if by == byName {
+		if name == "" {
+			return "", false
+		}
+		return name, true
+	}
+	return fallbackKey(id, name, order), true
+}
+```
+
+Set `DOMField.ID` from that identifier for both addressings, keeping `Name` as the raw
+attribute. Everything downstream — `Reconcile`, `Resolve`, the plan, the answer bank's
+topics — keeps working on one identifier and needs no change.
+
+Update the two callers of `ScanGreenhouseForm` (`client.go`, `preview_client.go`) to pass
+the layout. Task 3 and Task 4 rewrite those call sites properly; here, just make the build
+pass by looking the layout up at the call.
+
+Rename `greenhouseFormReadySelector` in `browser.go` to nothing — its value is now
+`layout.formSelector`, and `renderedHTML`'s callers pass it. Delete the constant.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/api/atsapply/ -v`
+Expected: PASS, the whole package. The pre-existing Greenhouse scan tests must pass
+unmodified — if one needed editing, the change moved behaviour it should not have.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/api/atsapply/
+go vet ./... && go test ./...
+git add internal/api/atsapply/
+git commit -F <a file containing a message explaining that the scan now identifies a field the way the platform does>
+```
+
+---
+
+### Task 3: Selecting and submitting by the layout
+
+**Files:**
+- Modify: `internal/api/atsapply/fill.go`
+- Modify: `internal/api/atsapply/fill_test.go` (if one exists; otherwise add the test to `layout_test.go`)
+
+**Interfaces:**
+- Consumes: `formLayout`, `byName` (Task 1).
+- Produces: `func fieldSelector(id string, by addressing) string`; `fillAndSubmit(ctx, plan, layout)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/api/atsapply/layout_test.go`:
+
+```go
+// The selector must address the field the same way the scan identified it — and a name
+// containing brackets (Lever's `urls[LinkedIn]` and `cards[<uuid>][field0]`) must survive
+// into a valid attribute selector.
+func TestFieldSelector_AddressesAFieldTheWayItsPlatformNamesIt(t *testing.T) {
+	if got := fieldSelector("first_name", byID); got != "#first_name" {
+		t.Errorf("byID selector = %q, want #first_name", got)
+	}
+	if got := fieldSelector("name", byName); got != `[name="name"]` {
+		t.Errorf("byName selector = %q, want [name=\"name\"]", got)
+	}
+	if got := fieldSelector("urls[LinkedIn]", byName); got != `[name="urls[LinkedIn]"]` {
+		t.Errorf("byName selector for a bracketed name = %q, want it quoted intact", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/api/atsapply/ -run TestFieldSelector`
+Expected: FAIL to build — `fieldSelector` takes one argument.
+
+- [ ] **Step 3: Make selection and submission layout-driven**
+
+In `internal/api/atsapply/fill.go`:
+
+```go
+// fieldSelector builds the CSS selector that addresses a field, the way its own platform
+// names it. A byName selector quotes the value, because Lever's names carry brackets
+// (`urls[LinkedIn]`, `cards[<uuid>][field0]`) that are syntax in an unquoted selector.
+func fieldSelector(id string, by addressing) string {
+	if by == byName {
+		return fmt.Sprintf("[name=%q]", id)
+	}
+	return "#" + id
+}
+```
+
+`fillOne` currently passes `chromedp.ByID` alongside the selector. Under `byName` that is
+wrong — the selector is a query, not an id. Take the query kind from the addressing in the
+same place the selector is built, so the two cannot disagree:
+
+```go
+// queryKind is how chromedp must interpret the selector this addressing produces.
+func (a addressing) queryKind() chromedp.QueryOption {
+	if a == byName {
+		return chromedp.ByQuery
+	}
+	return chromedp.ByID
+}
+```
+
+Thread the layout into `fillOne` and use both. Replace the hard-coded
+`greenhouseSubmitSelector` click in `fillAndSubmit` with `layout.submitSelector`, and delete
+the constant.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/api/atsapply/ -v`
+Expected: PASS, the whole package.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/api/atsapply/
+go vet ./... && go test ./...
+git add internal/api/atsapply/
+git commit -F <a file containing a message explaining that the selector and the query kind are one decision>
+```
+
+---
+
+### Task 4: Turning Lever on
+
+**Files:**
+- Modify: `internal/api/atsapply/client.go`
+- Modify: `internal/api/atsapply/preview_client.go`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing new — this is the switch.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/api/atsapply/layout_test.go`:
+
+```go
+// Lever can be filled. This is the switch the whole change exists to flip, and it is
+// asserted separately from the layout because the two are edited in different files and a
+// half-done change is exactly what TestLayoutFor_CoversEveryFillProvider guards against
+// from the other side.
+func TestFillProviders_IncludesLever(t *testing.T) {
+	if !fillProviders["lever"] {
+		t.Error("lever is not in fillProviders; its resolved plans still park as not-implemented")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/api/atsapply/ -run TestFillProviders`
+Expected: FAIL — `lever is not in fillProviders`.
+
+- [ ] **Step 3: Flip the switch and generalise the branch**
+
+In `internal/api/atsapply/client.go`, add `"lever": true` to `fillProviders`, with a comment
+naming what was measured (the live preview came back fully resolved; the form's controls
+were captured on 2026-09-09).
+
+Replace `if claimed.Provider == "greenhouse"` with a layout lookup:
+
+```go
+	layout, canDrive := layoutFor(claimed.Provider)
+	if canDrive {
+		// The providers this package can drive a browser against — see layout.go. A
+		// provider with no layout reaches neither a browser nor a submit click.
+		...
+	}
+```
+
+Pass `layout.formSelector` to `renderedHTML` and `layout` to `ScanForm` and `fillAndSubmit`.
+
+Make the same change in `preview_client.go`'s own Greenhouse branch — the preview must scan
+Lever's DOM too, or the candidate's preview and the submission would disagree about what
+the form contains.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/api/atsapply/ -v`
+Expected: PASS, including `TestLayoutFor_CoversEveryFillProvider`, which is now
+load-bearing: it fails if a provider is added to one of the two places and not the other.
+
+- [ ] **Step 5: Verify the whole build**
+
+Run: `go build ./... && go vet ./... && go test ./... && go vet -tags=integration ./...`
+Expected: all clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+gofmt -w internal/api/atsapply/
+git add internal/api/atsapply/
+git commit -F <a file containing a message explaining that Lever can now be filled, and what was measured to justify it>
+```
+
+---
+
+### Task 5: The package's own account of itself
+
+**Files:**
+- Modify: `internal/api/atsapply/AGENTS.md`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing.
+
+- [ ] **Step 1: Read what it currently says**
+
+Run: `cat internal/api/atsapply/AGENTS.md`
+
+It describes a package that drives Greenhouse alone. Find every statement that is now false
+— the provider list, the "one provider with a live DOM-scan" framing, anything naming
+`ScanGreenhouseForm` or `greenhouseSubmitSelector`.
+
+- [ ] **Step 2: Rewrite those statements**
+
+State, in the file's existing voice:
+
+- The registry is what makes a provider drivable, and a provider absent from it parks as
+  not-implemented.
+- Its three values are measured off a real posting, never inferred — with the two failures
+  that taught this named, since they are what an agent editing this file next needs to know:
+  the captcha marker that fired on the WORD "recaptcha" and parked every Greenhouse posting,
+  and the per-provider captcha list that decided what a page said before anyone loaded it.
+- Addressing is one setting because a mismatch between identification and selection is
+  silent — the field resolves, then cannot be typed into.
+- A submit click is irreversible, so an unconfirmed submission is never retried.
+
+Do not restate what the code already says plainly. This file is for what the code cannot
+say: why.
+
+- [ ] **Step 3: Verify the links resolve**
+
+Run: `pnpm check:links`
+Expected: every relative link resolves. This is a pre-commit hook as well; a renamed target
+is the usual cause of a failure here.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/api/atsapply/AGENTS.md
+git commit -F <a file containing a message explaining what the package's account of itself now says>
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| The registry (three values per provider) | 1 |
+| Addressing decides identification AND selection | 2, 3 |
+| A `byName` field with no name is dropped | 2 |
+| Radio groups need nothing new | covered — no change required; `fillOne`'s `checkbox_group` branch already selects `input[name=…][value=…]` |
+| Submitting via the layout's button | 3 |
+| Unconfirmed is not retried | unchanged — existing behaviour, asserted by existing tests |
+| Lever in `fillProviders` | 4 |
+| Preview scans Lever's DOM too | 4 |
+| Fixture reduced from real DOM | 2 |
+| Registry test covering every fill provider | 1 (written), 4 (made load-bearing) |
+| Live verification on entries 6 and 10 | deliberately NOT a task — it is a real application to a real employer, taken with the candidate's approval after this ships |
+
+**Type consistency:** `formLayout`, `addressing`, `byID`, `byName`, `layoutFor` are defined in Task 1 and used under those exact names in Tasks 2, 3 and 4. `ScanForm(pageHTML string, layout formLayout)` is defined in Task 2 and called in Task 4. `fieldSelector(id string, by addressing)` is defined in Task 3.
+
+**Placeholders:** none. The commit messages are described rather than written out, deliberately — a commit message asserting what was measured must be written by whoever ran the commands, not copied from a plan.
+
+**One thing the plan does NOT do:** it does not verify that an invisible hCaptcha lets a headless browser through. Nothing here can. Entries 6 and 10 carry no captcha at all, which is why they are the live check; what happens on a Lever posting that does carry one stays unknown until one is attempted, and the honest outcome for it is `StatusUnconfirmed`.

--- a/docs/superpowers/specs/2026-09-09-lever-fill-and-submit-design.md
+++ b/docs/superpowers/specs/2026-09-09-lever-fill-and-submit-design.md
@@ -1,0 +1,143 @@
+# Filling and submitting a Lever application
+
+**Status:** design, approved 2026-09-09
+**Problem owner:** auto-apply — Lever applications now resolve completely and still cannot be sent.
+
+## Where this starts
+
+Earlier today (#2721) the blanket `requiresCaptcha{"lever": true}` refusal was retired, on a
+live measurement: two of the candidate's own queued Lever postings render no captcha of any
+kind, four others carry an invisible hCaptcha, and the only "recaptcha" on any of them is a
+string inside a CSS rule.
+
+With the refusal gone, the preview pass reached Lever's schema for the first time. Queue
+entry 6 came back with **every field answered and nothing pending**:
+
+```
+Full name         Ilya Strelov
+Email             strelov1@gmail.com
+Phone             +55 48 99653-6547
+Current location  Florianópolis, Brazil
+```
+
+`fillProviders` still names Greenhouse alone, so `Submit` parks it as not-implemented. The
+data is there; the code to type it is not. That is the whole of this change.
+
+## What is already provider-agnostic
+
+Most of the pipeline is. `fillAndSubmit` (`internal/api/atsapply/fill.go`) fills from the
+resolved plan, clicks, and verifies against confirmation markers — none of it Greenhouse-
+specific. `Resolve`, `Reconcile`, the answer bank, the résumé attachment and the
+unconfirmed/parked outcomes are all shared.
+
+The provider is baked into exactly four places:
+
+| Where | What it hard-codes |
+|---|---|
+| `domscan.go:54` | `findByID(doc, "application-form")` |
+| `fill.go:141` | `fieldSelector` builds `"#" + id` |
+| `fill.go:74` | `greenhouseSubmitSelector = "#submit_app"` |
+| `client.go:181` | `if claimed.Provider == "greenhouse"` — whether to scan the DOM at all |
+
+## What actually differs, measured
+
+Captured from `jobs.lever.co/coderio/.../apply` on 2026-09-09:
+
+- **The form's id is `application-form` — the same as Greenhouse's.** A coincidence, and one
+  worth writing down as a value rather than relying on silently: the third provider will not
+  share it.
+- **Lever's fields carry no `id` at all.** `<input type="text" data-qa="name-input"
+  name="name" required>` — only `location-input` has one. Greenhouse addresses by `id`,
+  Lever by `name`. This is a property of the platforms, not a gap in our scan.
+- **The submit button is `#btn-submit`, and it is `type="button"`.** Clicking it runs
+  Lever's own JS, which performs the invisible hCaptcha when the employer enabled one and
+  then clicks the real, hidden `#hcaptchaSubmitBtn`. Nothing here needs to know that — we
+  click the button a person clicks.
+- Employer questions render as radio groups named `cards[<uuid>][field0]`, with values in
+  the posting's own language (`"Menos de 1 año"` on this Spanish-language posting).
+
+## The registry
+
+One table, three values per provider:
+
+```go
+type formLayout struct {
+    formSelector string // the element id the application form renders under
+    submitSelector string // the button a person clicks to submit
+    addressBy addressing // how a field is identified and selected: byID or byName
+}
+```
+
+The four sites above read from it. `ScanGreenhouseForm` loses "Greenhouse" from its name —
+it takes the layout and scans whatever form that names. `client.go`'s
+`if provider == "greenhouse"` becomes "this provider has a layout".
+
+**Why a table and not heuristics.** Finding the form by "the one with the most inputs" or
+the button by "the one that says Apply" is the class of guess this package has been burned
+by twice today — the captcha marker that fired on a word, and the provider list that decided
+what a page said before anyone looked at it. A submit click is irreversible; three measured
+values per provider are not a list of guesses, they are a description of a page somebody
+loaded.
+
+**Why not a per-provider code path.** A third provider would be a third copy of scan,
+select, click and verify, plus a fourth `if` in each of the four sites. The registry makes
+it one row.
+
+## Addressing
+
+`addressBy` decides two things that must agree:
+
+1. **Which attribute identifies a scanned field.** `scanControls` already records both `ID`
+   and `Name`. For a `byName` provider the field's identity IS its name — so the scan sets
+   `DOMField.ID` from `Name`, and everything downstream (`Reconcile`, `Resolve`, the plan,
+   the answer bank's topics) keeps working unchanged on one identifier.
+2. **How `fieldSelector` builds the CSS selector** — `#id` or `[name="..."]`.
+
+They are one setting because a mismatch between them is silent: fields would resolve and
+then not be found on the page.
+
+A `byName` field with no `name` attribute cannot be addressed at all, so the scan drops it
+rather than minting the synthetic key it currently gives an id-less, name-less control. That
+key exists so two such controls do not collide in the scan; for a `byName` provider it would
+instead produce a field that resolves and then cannot be typed into — the silent failure this
+setting exists to prevent. Dropping it means the platform's own schema is the only thing
+that can still declare the field required, which is the honest outcome: the entry parks.
+
+Lever's radio groups need nothing new — `fillOne`'s `checkbox_group` branch already selects
+`input[name=…][value=…]`, and `cards[<uuid>][field0]` is an ordinary attribute value.
+
+## Submitting
+
+Click `#btn-submit`, then verify with the existing markers. A click that produces no
+confirmation is `StatusUnconfirmed` — already a distinct, deliberately non-retried outcome.
+That matters more here than on Greenhouse: an invisible hCaptcha may refuse a headless
+browser, and the honest report is "we could not confirm it went through", never a retry that
+might submit twice.
+
+We do not know yet whether an invisible hCaptcha passes. This change is what makes the
+answer observable; the design does not assume either result.
+
+## What Lever still cannot do
+
+An employer's custom questions (`cards[...]`) have no answer until the candidate gives one.
+The screening answer bank (shipped today) is what collects them; until then such an entry
+parks with the questions listed, which is the correct outcome and not a regression.
+
+## Testing
+
+- **Fixture tests** over the captured Lever form: the scan finds the fields, identifies them
+  by name, and selects them the way `fillAndSubmit` would. The fixture is the real DOM,
+  reduced — the same rule the rest of this package now follows, after a hand-written
+  fixture passed while the live page failed.
+- **A registry test** asserting every provider in `fillProviders` has a layout, so adding
+  one without the other fails loudly rather than at a submit click.
+- **Live verification** on queue entries 6 and 10 — both Lever, both captcha-free, both
+  already fully resolved. This is a real application to a real employer, which is why it is
+  a deliberate step with the candidate's approval rather than a test.
+
+## Not in this design
+
+- Ashby, Workable, Recruitee. They have no fill path either, and the browser-use fallback
+  already in the code is a separate, metered decision.
+- Solving a rendered captcha challenge. Unchanged: those park.
+- Anything about which postings to apply to.

--- a/internal/api/atsapply/AGENTS.md
+++ b/internal/api/atsapply/AGENTS.md
@@ -19,8 +19,8 @@ all: Ashby and Workable, via the browser-use.com cloud agent API** (`browseruse_
 `openspec/changes/add-browseruse-atsapply-fallback`). This does not reopen the decision
 above — it is a plain HTTP client (`internal/platform/browseruse`), no second language or
 process, called only via `Client.WithBrowserUse`. Scope is deliberately narrow:
-- **Only Ashby and Workable** (`browserUseProviders`) — Greenhouse already has a fill path
-  and never reaches this branch; a white-label (unrecognized-layout) Greenhouse posting has
+- **Only Ashby and Workable** (`browserUseProviders`) — Greenhouse and Lever already have a
+  fill path and never reach this branch; a white-label (unrecognized-layout) Greenhouse posting has
   no `MergedField` schema to build a `Plan` from in the first place, since chromedp's own
   DOM scan is what failed there; a captcha-protected posting (Lever, or
   `reasonCaptchaProtected`) is never routed here — that would be an attempt to bypass a
@@ -74,12 +74,31 @@ process, called only via `Client.WithBrowserUse`. Scope is deliberately narrow:
 - **Never guesses an answer.** A select/checkbox's answer must match one of the platform's
   own offered option labels, or the field parks. An optional field with no known answer is
   left alone entirely (neither filled nor reported) — nothing here drafts text for it.
-- **A DOM-only live scan is built for Greenhouse only.** Lever always parks on its captcha
-  (`requiresCaptcha`, a static per-provider check, not DOM-based detection) before any
-  fetcher or browser is touched. Every other provider (Ashby, and anything reached in the
-  future) reconciles against `applyform.Form` alone — `mergedFromAPIOnly` — and a fully
-  resolved form for one of them still parks rather than being submitted through a fill path
-  never built or verified. Widening the live DOM-scan to another provider is a real gap to
+- **A platform is driven only if `layouts` (`layout.go`) describes its page.** That
+  description is three values — the element the form renders under, the button a person
+  clicks, and which attribute identifies a control — and each was read off a real posting.
+  Greenhouse and Lever have one; everything else reconciles against `applyform.Form` alone
+  (`mergedFromAPIOnly`) and parks as not-implemented however completely it resolved.
+
+  **The three values are measured, never inferred, and that is not a style preference.**
+  Locating the form as "the element with the most inputs", or the button by its text, is
+  what this package already did wrong twice in one day: `hasRecaptchaMarker` fired on the
+  mere WORD "recaptcha" and so parked every Greenhouse posting there is, and a
+  `requiresCaptcha{"lever": true}` list decided what a page said before anyone had loaded
+  the page — two of that candidate's own Lever postings carry no captcha at all. A submit
+  click cannot be withdrawn.
+
+  **Addressing is ONE setting, not two.** It decides both which attribute identifies a
+  scanned control and which selects it (`domscan.identify`, `fill.fieldSelector`,
+  `addressing.queryKind`). Splitting them fails silently: every field resolves, the plan
+  calls itself complete, and nothing is found on the page — at the last step, after the
+  model spend and after the candidate approved. A review caught exactly this in the
+  file-upload branch, which had kept a literal `chromedp.ByID`; under Lever's `byName` that
+  becomes `#[name="resume"]`, invalid CSS, on the one field every posting requires.
+  `TestFillOne_EveryActionOnTheSharedSelectorCarriesTheLayoutsQueryKind` reads the source to
+  keep it from coming back.
+
+  Widening the live DOM-scan to another provider is a real gap to
   close, not a design decision to defend.
 - **`fetchSchema` falls back to a stored form ONLY when no live fetcher is registered for
   the provider — not storage-first.** `Client.forms` (`WithStoredFormReader`, same
@@ -96,9 +115,9 @@ process, called only via `Client.WithBrowserUse`. Scope is deliberately narrow:
   Recruitee submit** — see this file's own note on `browserUseProviders`, above: reaching a
   `Plan` is not the same as having anything to hand it to. See
   `openspec/changes/atsapply-recruitee-stored-schema`.
-- **A Greenhouse posting whose form cannot be scanned parks with a named reason instead of
-  erroring.** `ScanGreenhouseForm`'s known selector (`greenhouseFormReadySelector`,
-  `#application-form`) only ever matched the vanilla `job-boards.greenhouse.io` template.
+- **A posting whose form cannot be scanned parks with a named reason instead of
+  erroring.** `ScanForm`'s selector comes from the layout, and Greenhouse's
+  (`#application-form`) only ever matched the vanilla `job-boards.greenhouse.io` template.
   Live verification found a real, likely-common case it does not: a white-label custom
   domain (a real GoDaddy posting on `careers.godaddy`) renders a completely different DOM id
   scheme and is gated by reCAPTCHA Enterprise on the form itself. `renderedHTML` (`browser.go`)
@@ -218,10 +237,11 @@ process, called only via `Client.WithBrowserUse`. Scope is deliberately narrow:
 
 ## How it works
 `Client.Submit`: captcha short-circuit → fetch the platform's schema via
-`applyform.Fetchers` → (Greenhouse only) launch a browser, render the page via `renderedHTML`
-(known selector, or — on that wait's own timeout — classify why via `classifyUnscannableForm`,
-which `Submit` maps to an early `StatusParked` return via `unscannableFormResult`),
-`ScanGreenhouseForm` → `Reconcile` → `Client.resolve`
+`applyform.Fetchers` → (only when `layoutFor` describes the platform) launch a browser,
+render the page via `renderedHTML` (the layout's own selector, or — on that wait's own
+timeout — classify why via `classifyUnscannableForm`, which `Submit` maps to an early
+`StatusParked` return via `unscannableFormResult`),
+`ScanForm` → `Reconcile` → `Client.resolve`
 (deterministic `Resolve`, then — if an experience-bank reader is configured —
 `ResolveWithDrafting` over what is still unmapped, via a freshly `llmkey.Bind`-ed
 `LLMDrafter`) → if `Plan.FullyResolved()`, `fillAndSubmit`; else return `StatusParked` with

--- a/internal/api/atsapply/browser.go
+++ b/internal/api/atsapply/browser.go
@@ -121,11 +121,6 @@ func renderedHTML(ctx context.Context, url, readySelector string) (string, error
 	return "", &unscannableFormError{reason: classifyUnscannableForm(currentHTML)}
 }
 
-// greenhouseFormReadySelector is Greenhouse's own form element id, confirmed against a
-// live posting in the 2026-09-02 spike. Only the vanilla job-boards.greenhouse.io template
-// is known to use it — a white-label custom domain may not (see classifyUnscannableForm).
-const greenhouseFormReadySelector = "application-form"
-
 // unscannableFormReason classifies why a Greenhouse posting's application form could not be
 // scanned, when its known selector never appeared.
 type unscannableFormReason string
@@ -155,7 +150,7 @@ func (e *unscannableFormError) Error() string {
 // classifyUnscannableForm inspects a page's already-rendered HTML (captured after its known
 // selector failed to appear within pageLoadTimeout) to tell a reCAPTCHA-gated form apart
 // from one whose layout this package simply does not recognize. Pure and fixture-testable,
-// the same way ScanGreenhouseForm already is — no further browser interaction needed to
+// the same way ScanForm already is — no further browser interaction needed to
 // classify.
 //
 // Narrow and named, matching resolve.go's "never guess" rule: this looks only for

--- a/internal/api/atsapply/browser.go
+++ b/internal/api/atsapply/browser.go
@@ -195,7 +195,7 @@ var recaptchaWidgetMarkers = []string{
 // The distinction is the whole point of this function, and it is not a nicety. EVERY
 // vanilla job-boards.greenhouse.io posting ships an invisible, score-based reCAPTCHA
 // Enterprise. The earlier unscoped `strings.Contains(html, "recaptcha")` therefore matched
-// every Greenhouse posting there is, and through previewGreenhouse's own check that parked
+// every Greenhouse posting there is, and through previewByLayout's own check that parked
 // the ONE provider this package can actually fill — before a single application was ever
 // attempted (freehire, 2026-09-08: 5 of the 10 entries the queue had ever held, all of them
 // on pages whose form scans fine in under two seconds).

--- a/internal/api/atsapply/client.go
+++ b/internal/api/atsapply/client.go
@@ -188,7 +188,10 @@ func (c *Client) Submit(ctx context.Context, claimed autoapply.Claimed, answers 
 		}
 		defer cancelBrowser()
 
-		pageHTML, err := renderedHTML(browserCtx, claimed.JobURL, greenhouseFormReadySelector)
+		// Safe to discard the lookup's ok here ONLY while this branch is gated to a provider
+		// the registry always holds. Lifting that gate must turn this into a real check.
+		layout, _ := layoutFor(claimed.Provider)
+		pageHTML, err := renderedHTML(browserCtx, claimed.JobURL, layout.formSelector)
 		if err != nil {
 			if result, parked := unscannableFormResult(err); parked {
 				return result, nil
@@ -203,7 +206,7 @@ func (c *Client) Submit(ctx context.Context, claimed autoapply.Claimed, answers 
 		if hasRecaptchaMarker(pageHTML) {
 			return autoapply.SidecarResult{Status: autoapply.StatusParked, Reason: string(reasonCaptchaProtected)}, nil
 		}
-		dom, err := ScanGreenhouseForm(pageHTML)
+		dom, err := ScanForm(pageHTML, layout)
 		if err != nil {
 			return autoapply.SidecarResult{}, fmt.Errorf("scan application form: %w", err)
 		}

--- a/internal/api/atsapply/client.go
+++ b/internal/api/atsapply/client.go
@@ -44,11 +44,20 @@ const tagAutoApplyDrafting = "auto-apply-drafting"
 // on the mere WORD "recaptcha" and parked every Greenhouse posting there is.
 
 // fillProviders is the single source of truth for which providers Submit can actually
-// fill/submit for — today, Greenhouse alone (see fillAndSubmit/browser.go). Checked both
-// before drafting is attempted (resolve, to avoid paying for a draft nothing can use) and
-// before a fill+submit is attempted (Submit) — one set, so the two can never drift apart.
+// fill/submit for. Checked both before drafting is attempted (resolve, to avoid paying for
+// a draft nothing can use) and before a fill+submit is attempted (Submit) — one set, so the
+// two can never drift apart.
+//
+// Every entry here must also have a layout (layout.go), and a test asserts the containment:
+// a provider Submit will try to fill, with no description of its page to fill it by, would
+// reach a submit click with selectors matching nothing.
 var fillProviders = map[string]bool{
 	"greenhouse": true,
+	// Measured 2026-09-09. Retiring the blanket captcha refusal (#2721) let the preview
+	// pass reach Lever's schema for the first time, and it came back with every field
+	// answered and nothing pending; the form's controls were captured from a live posting
+	// the same day (see leverform_test.go's fixture).
+	"lever": true,
 }
 
 // reasonSubmissionNotImplemented is the one park reason for two distinct gaps that both
@@ -178,19 +187,19 @@ func (c *Client) Submit(ctx context.Context, claimed autoapply.Claimed, answers 
 	var browserCtx context.Context
 	var cancelBrowser context.CancelFunc
 
-	if claimed.Provider == "greenhouse" {
-		// The one provider with a live DOM-scan built so far (design.md's scope note —
-		// the 2026-09-02 spike measured a real gap here; Ashby's API schema is an
-		// unverified-but-accepted assumption of completeness for now).
+	// Whether this package can drive a browser at this platform at all is the registry's
+	// answer, not a provider name spelled out here: adding a third platform is a row in
+	// layout.go rather than another branch. A provider with no layout reaches neither a
+	// browser nor a submit click, and Submit reports it as not-implemented below.
+	layout, canDrive := layoutFor(claimed.Provider)
+
+	if canDrive {
 		browserCtx, cancelBrowser, err = c.newBrowser(ctx)
 		if err != nil {
 			return autoapply.SidecarResult{}, fmt.Errorf("launch browser: %w", err)
 		}
 		defer cancelBrowser()
 
-		// Safe to discard the lookup's ok here ONLY while this branch is gated to a provider
-		// the registry always holds. Lifting that gate must turn this into a real check.
-		layout, _ := layoutFor(claimed.Provider)
 		pageHTML, err := renderedHTML(browserCtx, claimed.JobURL, layout.formSelector)
 		if err != nil {
 			if result, parked := unscannableFormResult(err); parked {
@@ -245,13 +254,13 @@ func (c *Client) Submit(ctx context.Context, claimed autoapply.Claimed, answers 
 				return result, err
 			}
 		}
-		// Fill/submit is only wired for Greenhouse so far — see fill.go. A form for
+		// Fill/submit is wired for the platforms in fillProviders — see layout.go. A form for
 		// another provider that DID fully resolve still parks rather than being
 		// submitted through a path never built or verified.
 		return autoapply.SidecarResult{Status: autoapply.StatusParked, Reason: reasonSubmissionNotImplemented}, nil
 	}
 	if browserCtx == nil {
-		return autoapply.SidecarResult{}, fmt.Errorf("internal error: no browser session for a Greenhouse submission")
+		return autoapply.SidecarResult{}, fmt.Errorf("internal error: no browser session for a submission this package can drive")
 	}
 
 	cleanup, parked := c.attachApprovedResume(ctx, claimed, &plan)
@@ -262,7 +271,7 @@ func (c *Client) Submit(ctx context.Context, claimed autoapply.Claimed, answers 
 		defer cleanup()
 	}
 
-	confirmed, err := fillAndSubmit(browserCtx, plan)
+	confirmed, err := fillAndSubmit(browserCtx, plan, layout)
 	if err != nil {
 		// A fill action failing, or the board EXPLICITLY refusing the submit click
 		// (SUBMIT_REFUSED_MARKERS in fill.go), both mean no submission happened — safe

--- a/internal/api/atsapply/domscan.go
+++ b/internal/api/atsapply/domscan.go
@@ -19,9 +19,17 @@ import (
 // internal/applyform's API-declared Field for the label/option text the DOM alone often
 // lacks.
 type DOMField struct {
-	// ID is the element's own id attribute — the selector this package fills by, and (for
-	// Greenhouse) the same identifier the platform expects back on submit. Empty for a
-	// checkbox/radio group, whose members share no single id; Name is authoritative there.
+	// ID is the identifier this control's own PLATFORM addresses it by — its `id` on
+	// Greenhouse, its `name` on Lever, whose inputs carry no id at all. Which attribute
+	// that is comes from the layout (see identify); everything downstream works on this
+	// one identifier and never asks where it came from.
+	//
+	// It is also what the platform expects back on submit, which is why the attribute has
+	// to be the platform's choice rather than ours: Lever's résumé upload carries the id
+	// `resume-upload-input` and posts under the name `resume`.
+	//
+	// Empty for a checkbox/radio group, whose members share no single id; Name is
+	// authoritative there. That predates the layout and is unchanged by it.
 	ID string
 	// Name is the DOM name attribute. For a checkbox/radio group it is the group's shared
 	// key; for everything else it usually equals ID and is kept for that case too.
@@ -42,25 +50,26 @@ type DOMField struct {
 	Options []string
 }
 
-// ScanGreenhouseForm parses a rendered Greenhouse application page's `#application-form`
-// into its field inventory. Pure function over an HTML string — no browser, no network —
-// mirroring internal/applyform's own FromLever, which parses markup the same way for a
-// platform whose form has no separate question API.
-func ScanGreenhouseForm(pageHTML string) ([]DOMField, error) {
+// ScanForm parses a rendered application page's form into its field inventory, per the
+// platform's own layout: which element the form renders under, and which attribute
+// identifies a control on it. Pure function over an HTML string — no browser, no network —
+// mirroring internal/ingest/applyform's own FromLever, which parses markup the same way for
+// a platform whose form has no separate question API.
+func ScanForm(pageHTML string, layout formLayout) ([]DOMField, error) {
 	doc, err := html.Parse(strings.NewReader(pageHTML))
 	if err != nil {
 		return nil, fmt.Errorf("parse page: %w", err)
 	}
-	form := findByID(doc, "application-form")
+	form := findByID(doc, layout.formSelector)
 	if form == nil {
-		return nil, fmt.Errorf("no #application-form on the page")
+		return nil, fmt.Errorf("no #%s on the page", layout.formSelector)
 	}
-	return scanControls(form), nil
+	return scanControls(form, layout.addressBy), nil
 }
 
 // scanControls walks a form node's input/select/textarea controls into DOMFields, grouping
 // checkbox/radio siblings that share a name into one field.
-func scanControls(form *html.Node) []DOMField {
+func scanControls(form *html.Node, by addressing) []DOMField {
 	var order []string // name/id order, so the returned slice matches document order
 	groups := map[string]*DOMField{}
 
@@ -89,11 +98,11 @@ func scanControls(form *html.Node) []DOMField {
 			}
 			switch n.Data {
 			case "input":
-				scanInput(n, &order, groups)
+				scanInput(n, by, &order, groups)
 			case "textarea":
-				scanSimple(n, "textarea", &order, groups)
+				scanSimple(n, "textarea", by, &order, groups)
 			case "select":
-				scanSimple(n, "select", &order, groups)
+				scanSimple(n, "select", by, &order, groups)
 			}
 		}
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
@@ -109,7 +118,7 @@ func scanControls(form *html.Node) []DOMField {
 	return out
 }
 
-func scanInput(n *html.Node, order *[]string, groups map[string]*DOMField) {
+func scanInput(n *html.Node, by addressing, order *[]string, groups map[string]*DOMField) {
 	typ := attr(n, "type")
 	if typ == "hidden" {
 		// Platform-filled, never a candidate answer — see the package doc.
@@ -119,8 +128,14 @@ func scanInput(n *html.Node, order *[]string, groups map[string]*DOMField) {
 	name := attr(n, "name")
 
 	if typ == "checkbox" || typ == "radio" {
+		// A group is keyed by the name its members share — that is what makes them one
+		// question — so byName needs no special case here. byID still falls back to the
+		// id when a group carries no name at all.
 		key := name
 		if key == "" {
+			if by == byName {
+				return
+			}
 			key = id
 		}
 		g, ok := groups[key]
@@ -140,20 +155,52 @@ func scanInput(n *html.Node, order *[]string, groups map[string]*DOMField) {
 	if typ == "file" {
 		kind = "file"
 	}
-	key := fallbackKey(id, name, order)
-	if _, ok := groups[key]; ok {
-		return // a real duplicate of an already-keyed (id or name) field — stay idempotent
+	key, addressable := identify(id, name, by, order)
+	if !addressable {
+		return
 	}
-	groups[key] = &DOMField{ID: id, Name: name, Kind: kind, Required: hasAttr(n, "required")}
+	if _, ok := groups[key]; ok {
+		return // a real duplicate of an already-keyed field — stay idempotent
+	}
+	groups[key] = &DOMField{ID: key, Name: name, Kind: kind, Required: hasAttr(n, "required")}
 	*order = append(*order, key)
 }
 
-func scanSimple(n *html.Node, kind string, order *[]string, groups map[string]*DOMField) {
+func scanSimple(n *html.Node, kind string, by addressing, order *[]string, groups map[string]*DOMField) {
 	id := attr(n, "id")
 	name := attr(n, "name")
-	key := fallbackKey(id, name, order)
-	groups[key] = &DOMField{ID: id, Name: name, Kind: kind, Required: hasAttr(n, "required")}
+	key, addressable := identify(id, name, by, order)
+	if !addressable {
+		return
+	}
+	groups[key] = &DOMField{ID: key, Name: name, Kind: kind, Required: hasAttr(n, "required")}
 	*order = append(*order, key)
+}
+
+// identify returns the identifier this layout addresses a control by, and whether the
+// control can be addressed at all.
+//
+// Under byName a control with no name is DROPPED rather than given fallbackKey's synthetic
+// key. That key exists so two anonymous controls do not collide in one scan; under byName it
+// would instead mint a field that resolves, reports the plan complete, and then cannot be
+// typed into — the silent last-step failure the addressing setting exists to prevent. What
+// remains able to declare such a control required is the platform's own schema, and an
+// attempt for it parks, which is honest.
+//
+// The returned identifier is what DOMField.ID carries, for BOTH addressings: everything
+// downstream — Reconcile, Resolve, the plan, the answer bank's topics — works on one
+// identifier, and which attribute it came from is this function's business alone. Lever's
+// résumé upload and location autocomplete both carry an id that differs from the name the
+// platform posts under, so preferring the id there would resolve a field Lever has never
+// heard of.
+func identify(id, name string, by addressing, order *[]string) (string, bool) {
+	if by == byName {
+		if name == "" {
+			return "", false
+		}
+		return name, true
+	}
+	return fallbackKey(id, name, order), true
 }
 
 // fallbackKey is id, or name when id is empty, or — when BOTH are empty — a synthetic key

--- a/internal/api/atsapply/domscan_test.go
+++ b/internal/api/atsapply/domscan_test.go
@@ -24,7 +24,7 @@ const greenhouseFixtureHTML = `
 `
 
 func TestScanGreenhouseForm_ExtractsPlainFields(t *testing.T) {
-	fields, err := ScanGreenhouseForm(greenhouseFixtureHTML)
+	fields, err := ScanForm(greenhouseFixtureHTML, greenhouseTestLayout())
 	if err != nil {
 		t.Fatalf("ScanGreenhouseForm: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestScanGreenhouseForm_ExtractsPlainFields(t *testing.T) {
 }
 
 func TestScanGreenhouseForm_SkipsHiddenFields(t *testing.T) {
-	fields, err := ScanGreenhouseForm(greenhouseFixtureHTML)
+	fields, err := ScanForm(greenhouseFixtureHTML, greenhouseTestLayout())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestScanGreenhouseForm_SkipsHiddenFields(t *testing.T) {
 }
 
 func TestScanGreenhouseForm_GroupsACheckboxGroupByName(t *testing.T) {
-	fields, err := ScanGreenhouseForm(greenhouseFixtureHTML)
+	fields, err := ScanForm(greenhouseFixtureHTML, greenhouseTestLayout())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestScanGreenhouseForm_GroupsACheckboxGroupByName(t *testing.T) {
 }
 
 func TestScanGreenhouseForm_NoApplicationFormIsAnError(t *testing.T) {
-	if _, err := ScanGreenhouseForm(`<html><body>not a form page</body></html>`); err == nil {
+	if _, err := ScanForm(`<html><body>not a form page</body></html>`, greenhouseTestLayout()); err == nil {
 		t.Fatal("want an error when #application-form is not on the page")
 	}
 }
@@ -98,7 +98,7 @@ func TestScanGreenhouseForm_APlainInputWithNoIDOrNameIsStillScanned(t *testing.T
 	  <input type="text" required>
 	</form></body></html>`
 
-	fields, err := ScanGreenhouseForm(html)
+	fields, err := ScanForm(html, greenhouseTestLayout())
 	if err != nil {
 		t.Fatalf("ScanGreenhouseForm: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestScanGreenhouseForm_TwoPlainInputsWithNoIDOrNameDoNotCollide(t *testing.
 	  <input type="text" required>
 	</form></body></html>`
 
-	fields, err := ScanGreenhouseForm(html)
+	fields, err := ScanForm(html, greenhouseTestLayout())
 	if err != nil {
 		t.Fatalf("ScanGreenhouseForm: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestScanGreenhouseForm_ATextareaWithNoIDOrNameIsStillScanned(t *testing.T) 
 	  <textarea required></textarea>
 	</form></body></html>`
 
-	fields, err := ScanGreenhouseForm(html)
+	fields, err := ScanForm(html, greenhouseTestLayout())
 	if err != nil {
 		t.Fatalf("ScanGreenhouseForm: %v", err)
 	}
@@ -173,7 +173,7 @@ const greenhouseRequiredProxyInputsHTML = `
 // attempt on a vanilla Greenhouse posting could never be submitted no matter how complete
 // the candidate's profile was. Production carried four of these on every posting.
 func TestScanGreenhouseForm_SkipsAriaHiddenRequiredProxyInputs(t *testing.T) {
-	fields, err := ScanGreenhouseForm(greenhouseRequiredProxyInputsHTML)
+	fields, err := ScanForm(greenhouseRequiredProxyInputsHTML, greenhouseTestLayout())
 	if err != nil {
 		t.Fatalf("ScanGreenhouseForm: %v", err)
 	}
@@ -183,4 +183,14 @@ func TestScanGreenhouseForm_SkipsAriaHiddenRequiredProxyInputs(t *testing.T) {
 	if fields[0].ID != "first_name" {
 		t.Errorf("scanned field = %+v, want the real first_name input", fields[0])
 	}
+}
+
+// greenhouseTestLayout is the layout these tests scan under. A helper rather than a literal
+// so a change to Greenhouse's own page description reaches every test that depends on it.
+func greenhouseTestLayout() formLayout {
+	l, ok := layoutFor("greenhouse")
+	if !ok {
+		panic("greenhouse has no layout")
+	}
+	return l
 }

--- a/internal/api/atsapply/fill.go
+++ b/internal/api/atsapply/fill.go
@@ -57,28 +57,32 @@ var submitRefusedMarkers = []string{
 // This is the least-verified part of the package — see design.md's Testing section and
 // task 7.1: correctness here rests on the 2026-09-02 spike's single live posting and the
 // reference implementation's own measured rules, not on this package's own live testing.
-func fillAndSubmit(ctx context.Context, plan Plan) (bool, error) {
+func fillAndSubmit(ctx context.Context, plan Plan, layout formLayout) (bool, error) {
 	for _, f := range plan.Fields {
-		if err := fillOne(ctx, f); err != nil {
+		if err := fillOne(ctx, f, layout.addressBy); err != nil {
 			return false, fmt.Errorf("fill %q: %w", f.ID, err)
 		}
 	}
 
-	if err := chromedp.Run(ctx, chromedp.Click(greenhouseSubmitSelector, chromedp.ByQuery)); err != nil {
+	if err := chromedp.Run(ctx, chromedp.Click(layout.submitSelector, chromedp.ByQuery)); err != nil {
 		return false, fmt.Errorf("click submit: %w", err)
 	}
 
 	return verifySubmission(ctx)
 }
 
-// greenhouseSubmitSelector is Greenhouse's own submit button id.
-const greenhouseSubmitSelector = "#submit_app"
-
-func fillOne(parent context.Context, f ResolvedField) error {
+func fillOne(parent context.Context, f ResolvedField, by addressing) error {
 	ctx, cancel := context.WithTimeout(parent, fillTimeout)
 	defer cancel()
 
-	sel := fieldSelector(f.ID)
+	// sel and kind are ONE decision, taken once here: a `[name=…]` selector handed to a
+	// by-id lookup is silently rewritten to `#[name=…]`, which is invalid CSS and matches
+	// nothing. Every branch below MUST pass `kind` — a review caught the file branch
+	// hard-coding chromedp.ByID, which would have meant no Lever application carrying a
+	// résumé could ever be submitted, on a page where the résumé is required. There is a
+	// test asserting no branch reintroduces a literal query kind.
+	sel := fieldSelector(f.ID, by)
+	kind := by.queryKind()
 
 	switch f.Kind {
 	case "textarea", "text":
@@ -102,9 +106,9 @@ func fillOne(parent context.Context, f ResolvedField) error {
 		// outcome, which is exactly why StatusUnconfirmed exists as a distinct,
 		// non-retried outcome rather than trusting any of this always worked.
 		return chromedp.Run(ctx,
-			chromedp.Clear(sel, chromedp.ByID),
-			chromedp.SendKeys(sel, f.Value, chromedp.ByID),
-			chromedp.SendKeys(sel, kb.Enter, chromedp.ByID),
+			chromedp.Clear(sel, kind),
+			chromedp.SendKeys(sel, f.Value, kind),
+			chromedp.SendKeys(sel, kb.Enter, kind),
 		)
 	case "select":
 		// SetValue sets the DOM .value property directly, which a React-controlled
@@ -113,7 +117,7 @@ func fillOne(parent context.Context, f ResolvedField) error {
 		// unset even though the raw DOM value looks right. Dispatching the events a
 		// real interaction would fire is what makes React notice.
 		return chromedp.Run(ctx,
-			chromedp.SetValue(sel, f.Value, chromedp.ByID),
+			chromedp.SetValue(sel, f.Value, kind),
 			chromedp.Evaluate(fmt.Sprintf(dispatchChangeEventsJS, sel), nil),
 		)
 	case "checkbox_group":
@@ -128,16 +132,26 @@ func fillOne(parent context.Context, f ResolvedField) error {
 		// rendered the approved tailored CV and overwritten Value with the temp PDF's
 		// path — never a candidate-authored string, so no further validation of Value
 		// belongs here.
-		return chromedp.Run(ctx, chromedp.SetUploadFiles(sel, []string{f.Value}, chromedp.ByID))
+		return chromedp.Run(ctx, chromedp.SetUploadFiles(sel, []string{f.Value}, kind))
 	default:
 		return fmt.Errorf("no fill strategy for kind %q", f.Kind)
 	}
 }
 
-// fieldSelector resolves a merged field's id to a DOM selector. IDs from this package's own
-// scan are element ids; `#id` is correct for every kind ScanGreenhouseForm produces except
-// checkbox_group, which fillOne selects by name+value directly instead.
-func fieldSelector(id string) string {
+// fieldSelector resolves a field's identifier to a DOM selector, the way its own platform
+// names it. The identifier is whatever the layout addressed the control by (see
+// domscan.identify) — an element id on Greenhouse, a name on Lever.
+//
+// A byName selector quotes the value because Lever's names carry brackets:
+// `urls[LinkedIn]`, and every employer question as `cards[<uuid>][field0]`. Unquoted,
+// brackets are selector syntax and the lookup silently matches nothing.
+//
+// checkbox_group is the exception under either addressing: fillOne selects those by
+// name+value directly, since a group's members share a name rather than an identifier.
+func fieldSelector(id string, by addressing) string {
+	if by == byName {
+		return fmt.Sprintf("[name=%q]", id)
+	}
 	return "#" + id
 }
 

--- a/internal/api/atsapply/layout.go
+++ b/internal/api/atsapply/layout.go
@@ -1,0 +1,65 @@
+package atsapply
+
+// addressing is how a platform identifies a control on its own application form — which
+// attribute names it, and therefore which attribute selects it.
+//
+// It is ONE setting rather than two because the two must agree. If the scan identified a
+// field by one attribute while the fill selected it by another, nothing would report an
+// error: every field would resolve, the plan would call itself complete, and no control
+// would be found on the page — at the last step, after the model spend and after the
+// candidate approved the application.
+type addressing int
+
+const (
+	// byID identifies a control by its `id`. Greenhouse names every one of them.
+	byID addressing = iota
+	// byName identifies a control by its `name`. Lever's inputs carry no id at all —
+	// `<input type="text" data-qa="name-input" name="name" required>` — measured on
+	// jobs.lever.co/coderio/6ce0e52b-e7bc-462f-ac9e-1d31c8c0e037/apply, 2026-09-09.
+	byName
+)
+
+// formLayout is what this package needs to know about one platform's application page:
+// three values, each of which somebody read off a real posting.
+//
+// A table rather than heuristics, deliberately. Finding the form as "the element with the
+// most inputs", or the button as "the one whose text says Apply", is the shape of the two
+// failures this package had in a single day: a captcha marker that fired on the mere WORD
+// "recaptcha" and so parked every Greenhouse posting there is, and a per-provider captcha
+// list that decided what a page said before anyone had loaded the page. A submit click
+// cannot be withdrawn, so what drives one is measured.
+type formLayout struct {
+	// formSelector is the element id the application form renders under — the bare id,
+	// no leading '#', because renderedHTML waits on it with chromedp.ByID and the DOM
+	// scan finds it by id.
+	formSelector string
+	// submitSelector is the CSS selector for the button a PERSON clicks. On Lever that is
+	// #btn-submit, a type="button" whose own JS performs the invisible hCaptcha when the
+	// employer enabled one and then clicks the real, hidden #hcaptchaSubmitBtn. This
+	// package clicks the visible one and does not model the rest: driving the hidden
+	// button directly would bypass the page's own submission logic.
+	submitSelector string
+	// addressBy is how a control on this platform is named, and so how it is selected.
+	addressBy addressing
+}
+
+// layouts is every platform this package can drive a browser against.
+//
+// Nothing consults it yet — Submit still gates on fillProviders alone, and the two are
+// wired together later in this same change. Until then this table is the description, not
+// the gate.
+//
+// Both entries happen to name the form `application-form`. That is written out per
+// platform rather than shared: the third platform will not share it, and a shared constant
+// would have to be un-shared under time pressure.
+var layouts = map[string]formLayout{
+	"greenhouse": {formSelector: "application-form", submitSelector: "#submit_app", addressBy: byID},
+	"lever":      {formSelector: "application-form", submitSelector: "#btn-submit", addressBy: byName},
+}
+
+// layoutFor returns the platform's page description, or false when this package cannot
+// drive it.
+func layoutFor(provider string) (formLayout, bool) {
+	l, ok := layouts[provider]
+	return l, ok
+}

--- a/internal/api/atsapply/layout.go
+++ b/internal/api/atsapply/layout.go
@@ -1,5 +1,7 @@
 package atsapply
 
+import "github.com/chromedp/chromedp"
+
 // addressing is how a platform identifies a control on its own application form — which
 // attribute names it, and therefore which attribute selects it.
 //
@@ -45,9 +47,8 @@ type formLayout struct {
 
 // layouts is every platform this package can drive a browser against.
 //
-// Nothing consults it yet — Submit still gates on fillProviders alone, and the two are
-// wired together later in this same change. Until then this table is the description, not
-// the gate.
+// Submit and the preview pass both consult it to decide whether to launch a browser at all,
+// and fillProviders must agree with it — a test asserts the containment.
 //
 // Both entries happen to name the form `application-form`. That is written out per
 // platform rather than shared: the third platform will not share it, and a shared constant
@@ -55,6 +56,17 @@ type formLayout struct {
 var layouts = map[string]formLayout{
 	"greenhouse": {formSelector: "application-form", submitSelector: "#submit_app", addressBy: byID},
 	"lever":      {formSelector: "application-form", submitSelector: "#btn-submit", addressBy: byName},
+}
+
+// queryKind is how chromedp must interpret the selector this addressing produces. It lives
+// beside the addressing rather than at the call site so a selector and the lookup that
+// consumes it come from one value: a `[name=…]` selector handed to a by-id lookup finds
+// nothing, and finds it silently.
+func (a addressing) queryKind() chromedp.QueryOption {
+	if a == byName {
+		return chromedp.ByQuery
+	}
+	return chromedp.ByID
 }
 
 // layoutFor returns the platform's page description, or false when this package cannot

--- a/internal/api/atsapply/layout_test.go
+++ b/internal/api/atsapply/layout_test.go
@@ -1,6 +1,11 @@
 package atsapply
 
-import "testing"
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+)
 
 // The two platforms this package can drive, and the values it drives them by.
 //
@@ -53,5 +58,87 @@ func TestLayoutFor_CoversEveryFillProvider(t *testing.T) {
 		if _, ok := layoutFor(provider); !ok {
 			t.Errorf("%q is in fillProviders but has no layout", provider)
 		}
+	}
+}
+
+// The selector must address a field the way its platform names it — and a name carrying
+// brackets (Lever's `urls[LinkedIn]`, and every employer question as
+// `cards[<uuid>][field0]`) must survive quoted intact, since brackets are selector syntax
+// when unquoted.
+func TestFieldSelector_AddressesAFieldTheWayItsPlatformNamesIt(t *testing.T) {
+	if got := fieldSelector("first_name", byID); got != "#first_name" {
+		t.Errorf("byID selector = %q, want #first_name", got)
+	}
+	if got := fieldSelector("name", byName); got != `[name="name"]` {
+		t.Errorf("byName selector = %q, want [name=\"name\"]", got)
+	}
+	if got := fieldSelector("urls[LinkedIn]", byName); got != `[name="urls[LinkedIn]"]` {
+		t.Errorf("byName selector for a bracketed name = %q, want it quoted intact", got)
+	}
+}
+
+// The selector and the way chromedp interprets it come from one value, so they cannot
+// disagree: a `[name=…]` selector handed to a by-id lookup finds nothing, silently.
+func TestAddressing_QueryKindMatchesTheSelectorItProduces(t *testing.T) {
+	if byID.queryKind() == nil || byName.queryKind() == nil {
+		t.Fatal("an addressing produced no query kind")
+	}
+	if fmt.Sprintf("%p", byID.queryKind()) == fmt.Sprintf("%p", byName.queryKind()) {
+		t.Error("both addressings resolve to the same chromedp query kind; one of them cannot be right")
+	}
+}
+
+// Lever can be filled. This is the switch the whole change exists to flip, and it is
+// asserted separately from the layout because the two live in different files — which is
+// exactly what TestLayoutFor_CoversEveryFillProvider guards from the other side.
+func TestFillProviders_IncludesLever(t *testing.T) {
+	if !fillProviders["lever"] {
+		t.Error("lever is not in fillProviders; its resolved plans still park as not-implemented")
+	}
+}
+
+// Every chromedp call that acts on `sel` must carry the layout's own query kind, never a
+// literal.
+//
+// This reads the source rather than exercising the code because the failure it guards is
+// invisible to any test that does not drive a real browser: chromedp.ByID silently rewrites
+// a `[name=…]` selector to `#[name=…]`, which is invalid CSS matching nothing. A review
+// found exactly that in the file-upload branch — under byName it would have meant no Lever
+// application carrying a résumé could ever be submitted, on pages where the résumé is
+// required, with every unit test still green.
+//
+// It checks lines acting on `sel` specifically, not the whole function: the checkbox_group
+// branch builds its own `optSel` from name+value, which is a query selector under either
+// addressing, and naming ByQuery there is correct.
+//
+// Reading source is an unusual test. It is the honest one here: the rule is a property of
+// the text, and the alternative is trusting every branch to be edited correctly forever.
+func TestFillOne_EveryActionOnTheSharedSelectorCarriesTheLayoutsQueryKind(t *testing.T) {
+	src, err := os.ReadFile("fill.go")
+	if err != nil {
+		t.Fatalf("read fill.go: %v", err)
+	}
+	start := bytes.Index(src, []byte("func fillOne("))
+	if start < 0 {
+		t.Fatal("fillOne not found in fill.go — this test is pinned to that function")
+	}
+	end := bytes.Index(src[start:], []byte("\nfunc "))
+	if end < 0 {
+		end = len(src) - start
+	}
+
+	checked := 0
+	for _, line := range bytes.Split(src[start:start+end], []byte("\n")) {
+		trimmed := bytes.TrimSpace(line)
+		if bytes.HasPrefix(trimmed, []byte("//")) || !bytes.Contains(trimmed, []byte("(sel,")) {
+			continue
+		}
+		checked++
+		if !bytes.Contains(trimmed, []byte("kind")) {
+			t.Errorf("this line acts on sel without the layout's query kind:\n\t%s", trimmed)
+		}
+	}
+	if checked == 0 {
+		t.Error("no line acting on sel was found; this test is no longer pinned to anything")
 	}
 }

--- a/internal/api/atsapply/layout_test.go
+++ b/internal/api/atsapply/layout_test.go
@@ -1,0 +1,57 @@
+package atsapply
+
+import "testing"
+
+// The two platforms this package can drive, and the values it drives them by.
+//
+// Every number and string here was read off a live posting, which is the point: a submit
+// click cannot be withdrawn, so what triggers one is measured rather than inferred. See
+// layout.go's own comment for the two occasions this package inferred instead.
+func TestLayoutFor_KnowsTheTwoProvidersWithAFillPath(t *testing.T) {
+	gh, ok := layoutFor("greenhouse")
+	if !ok {
+		t.Fatal("greenhouse has no layout")
+	}
+	want := formLayout{formSelector: "application-form", submitSelector: "#submit_app", addressBy: byID}
+	if gh != want {
+		t.Errorf("greenhouse layout = %+v, want %+v", gh, want)
+	}
+
+	// Measured on jobs.lever.co/coderio/6ce0e52b-e7bc-462f-ac9e-1d31c8c0e037/apply,
+	// 2026-09-09: the form carries the same id Greenhouse's does, the button a person
+	// clicks is #btn-submit, and the inputs carry no id at all — only name.
+	lv, ok := layoutFor("lever")
+	if !ok {
+		t.Fatal("lever has no layout")
+	}
+	wantLever := formLayout{formSelector: "application-form", submitSelector: "#btn-submit", addressBy: byName}
+	if lv != wantLever {
+		t.Errorf("lever layout = %+v, want %+v", lv, wantLever)
+	}
+}
+
+// A platform nobody measured is never driven. Its attempts park for the reason that is true
+// of them — no fill path exists — rather than reaching a browser on a page this package
+// knows nothing about.
+func TestLayoutFor_RefusesAProviderWithNoFillPath(t *testing.T) {
+	for _, provider := range []string{"ashby", "workable", "recruitee", ""} {
+		if _, ok := layoutFor(provider); ok {
+			t.Errorf("layoutFor(%q) returned a layout; no fill path exists for it", provider)
+		}
+	}
+}
+
+// The registry and fillProviders answer one question in two files, and must not drift: a
+// platform Submit will try to fill, with no layout to fill it by, would reach a submit
+// click with selectors matching nothing.
+//
+// This passes trivially while Greenhouse is the only entry in fillProviders. It starts
+// carrying weight when a platform is added THERE — adding one to layouts alone creates no
+// risk, since the containment runs in one direction only.
+func TestLayoutFor_CoversEveryFillProvider(t *testing.T) {
+	for provider := range fillProviders {
+		if _, ok := layoutFor(provider); !ok {
+			t.Errorf("%q is in fillProviders but has no layout", provider)
+		}
+	}
+}

--- a/internal/api/atsapply/leverform_test.go
+++ b/internal/api/atsapply/leverform_test.go
@@ -1,0 +1,142 @@
+package atsapply
+
+import "testing"
+
+// Reduced from the live DOM of jobs.lever.co/coderio/6ce0e52b-e7bc-462f-ac9e-1d31c8c0e037/apply,
+// captured 2026-09-09 from the production host. Every attribute below is verbatim; only
+// markup between the controls was dropped.
+//
+// What it is here to show is that Lever's controls cannot be addressed by `id`. Most carry
+// none at all; the résumé upload and the location autocomplete carry one, and in both cases
+// it is a DIFFERENT string from the `name` the platform posts under — which is the trap a
+// scan addressing by id would fall into silently, resolving a field Lever never heard of.
+const leverFormHTML = `
+<html><body>
+<form id="application-form" enctype="multipart/form-data" method="POST">
+  <select name="opportunityLocationId" class="opportunity-location" data-qa="opportunity-location-select"></select>
+  <input class="application-file-input invisible-resume-upload" data-qa="input-resume" id="resume-upload-input" name="resume" tabindex="-1" type="file">
+  <input type="text" data-qa="name-input" name="name" required="">
+  <input name="email" data-qa="email-input" type="email" required="">
+  <input type="text" data-qa="phone-input" name="phone" required="">
+  <input class="location-input" data-qa="location-input" id="location-input" type="text" maxlength="100" name="location">
+  <input type="text" data-qa="org-input" name="org">
+  <input type="text" name="urls[LinkedIn]" required="">
+  <input type="text" name="urls[GitHub]">
+  <input type="radio" name="cards[192519c4-2fbe-4575-9ab0-db6643cd5135][field0]" value="Menos de 1 año" required="required">
+  <input type="radio" name="cards[192519c4-2fbe-4575-9ab0-db6643cd5135][field0]" value="Entre 1 y 2 años" required="required">
+  <button id="hcaptchaSubmitBtn" type="submit" class="hidden"></button>
+  <button id="btn-submit" type="button" data-qa="btn-submit">Submit application</button>
+</form>
+</body></html>
+`
+
+// Under byName addressing a field's identity is its name, because that is the only thing
+// Lever's controls carry — and it is what the platform posts under.
+func TestScanForm_IdentifiesLeverFieldsByName(t *testing.T) {
+	layout, _ := layoutFor("lever")
+
+	fields, err := ScanForm(leverFormHTML, layout)
+	if err != nil {
+		t.Fatalf("ScanForm: %v", err)
+	}
+
+	found := map[string]DOMField{}
+	for _, f := range fields {
+		found[f.ID] = f
+	}
+	for _, want := range []string{"name", "email", "phone", "location", "resume", "org", "urls[LinkedIn]", "opportunityLocationId"} {
+		if _, ok := found[want]; !ok {
+			t.Errorf("no field identified as %q; scanned %+v", want, fields)
+		}
+	}
+	if got := found["resume"].Kind; got != "file" {
+		t.Errorf("resume kind = %q, want file", got)
+	}
+	if got := found["opportunityLocationId"].Kind; got != "select" {
+		t.Errorf("opportunityLocationId kind = %q, want select", got)
+	}
+	// A radio group is the one field DOMField.ID is deliberately empty for — its members
+	// share a name, not an id, and Name is authoritative there (see DOMField's own doc).
+	// That predates this change and is not altered by it, so the group is looked up the way
+	// the type says to.
+	var group *DOMField
+	for i := range fields {
+		if fields[i].Name == "cards[192519c4-2fbe-4575-9ab0-db6643cd5135][field0]" {
+			group = &fields[i]
+		}
+	}
+	if group == nil {
+		t.Fatalf("the employer's radio group was not scanned; got %+v", fields)
+	}
+	if group.Kind != "checkbox_group" {
+		t.Errorf("the radio group's kind = %q, want checkbox_group", group.Kind)
+	}
+	if len(group.Options) != 2 {
+		t.Errorf("the radio group carries %d options, want both values", len(group.Options))
+	}
+}
+
+// The two controls that DO carry an id carry a different one from the name Lever posts
+// under. Identifying by the id would resolve a field the platform has never heard of, and
+// the failure would not surface until the fill found nothing on the page.
+func TestScanForm_PrefersTheNameOverAnIdThatDiffersFromIt(t *testing.T) {
+	layout, _ := layoutFor("lever")
+
+	fields, err := ScanForm(leverFormHTML, layout)
+	if err != nil {
+		t.Fatalf("ScanForm: %v", err)
+	}
+
+	for _, f := range fields {
+		if f.ID == "location-input" || f.ID == "resume-upload-input" {
+			t.Errorf("a field was identified by its id (%q) rather than the name Lever posts under", f.ID)
+		}
+	}
+}
+
+// The platform that already worked must keep working: a Greenhouse control is still
+// identified by its id.
+func TestScanForm_StillIdentifiesGreenhouseFieldsByID(t *testing.T) {
+	layout, _ := layoutFor("greenhouse")
+
+	fields, err := ScanForm(greenhouseFixtureHTML, layout)
+	if err != nil {
+		t.Fatalf("ScanForm: %v", err)
+	}
+	if len(fields) == 0 {
+		t.Fatal("no fields scanned from the vanilla Greenhouse fixture")
+	}
+	for _, f := range fields {
+		// A checkbox/radio group is exempt: DOMField.ID is empty for one by design, since
+		// its members share a name rather than an id. Every other control on a Greenhouse
+		// page carries an id, and identifying one by anything else would move behaviour
+		// for the platform that already worked.
+		if f.Kind == "checkbox_group" {
+			continue
+		}
+		if f.ID == "" {
+			t.Errorf("a Greenhouse field came back with no identifier: %+v", f)
+		}
+	}
+}
+
+// A control a byName layout cannot address is dropped rather than given a synthetic key.
+//
+// Under byID such a control gets one so two anonymous controls do not collide in the scan.
+// Under byName that key would instead mint a field that resolves and then cannot be typed
+// into — the silent last-step failure the addressing setting exists to prevent.
+func TestScanForm_DropsANamelessFieldUnderByNameAddressing(t *testing.T) {
+	const html = `<html><body><form id="application-form">
+	  <input type="text" name="email">
+	  <input type="text" required="">
+	</form></body></html>`
+	layout, _ := layoutFor("lever")
+
+	fields, err := ScanForm(html, layout)
+	if err != nil {
+		t.Fatalf("ScanForm: %v", err)
+	}
+	if len(fields) != 1 || fields[0].ID != "email" {
+		t.Fatalf("scanned %+v, want only the addressable field", fields)
+	}
+}

--- a/internal/api/atsapply/preview_client.go
+++ b/internal/api/atsapply/preview_client.go
@@ -60,8 +60,10 @@ func (p *PreviewClient) Preview(ctx context.Context, claimed autoapply.Claimed, 
 	// ClaimAutoApplyBatch's own comment already documents for Claimed.TailoredCVID.
 	hasApprovedCV := claimed.TailoredCVID != uuid.Nil
 
-	if claimed.Provider == "greenhouse" {
-		return p.previewGreenhouse(ctx, claimed, answers, hasApprovedCV)
+	// Same registry the submission path consults. The preview must scan whatever DOM the
+	// submission will, or the candidate approves an answer set the fill never sees.
+	if _, canDrive := layoutFor(claimed.Provider); canDrive {
+		return p.previewByLayout(ctx, claimed, answers, hasApprovedCV)
 	}
 
 	apiForm, err := p.schemaFor(ctx, claimed)
@@ -95,10 +97,13 @@ func (p *PreviewClient) schemaFor(ctx context.Context, claimed autoapply.Claimed
 	})
 }
 
-// previewGreenhouse scans the live form exactly the way Client.Submit does for its own
-// Greenhouse branch, then closes the browser immediately — a preview never fills or
-// submits, so nothing here needs the session to outlive the scan.
-func (p *PreviewClient) previewGreenhouse(ctx context.Context, claimed autoapply.Claimed, answers map[string]string, hasApprovedCV bool) (autoapply.PreviewResult, error) {
+// previewByLayout scans the live form exactly the way Client.Submit does, for any platform
+// the registry holds a page description of, then closes the browser immediately — a preview
+// never fills or submits, so nothing here needs the session to outlive the scan.
+//
+// It must scan by the SAME layout the submission will, or the candidate approves an answer
+// set the fill never sees.
+func (p *PreviewClient) previewByLayout(ctx context.Context, claimed autoapply.Claimed, answers map[string]string, hasApprovedCV bool) (autoapply.PreviewResult, error) {
 	apiForm, err := p.schemaFor(ctx, claimed)
 	if err != nil {
 		return autoapply.PreviewResult{}, fmt.Errorf("fetch %s schema: %w", claimed.Provider, err)
@@ -110,9 +115,13 @@ func (p *PreviewClient) previewGreenhouse(ctx context.Context, claimed autoapply
 	}
 	defer cancel()
 
-	// Safe to discard the lookup's ok here ONLY while this branch is gated to a provider
-	// the registry always holds. Lifting that gate must turn this into a real check.
-	layout, _ := layoutFor(claimed.Provider)
+	layout, canDrive := layoutFor(claimed.Provider)
+	if !canDrive {
+		// Preview is only ever reached for a drivable platform (Preview's own branch
+		// above), so this cannot fire — but a lookup whose failure is discarded is how a
+		// later caller ends up scanning with a zero-valued layout.
+		return autoapply.PreviewResult{}, fmt.Errorf("no form layout for %q", claimed.Provider)
+	}
 	pageHTML, err := renderedHTML(browserCtx, claimed.JobURL, layout.formSelector)
 	if err != nil {
 		if result, parked := unscannableFormResult(err); parked {

--- a/internal/api/atsapply/preview_client.go
+++ b/internal/api/atsapply/preview_client.go
@@ -110,7 +110,10 @@ func (p *PreviewClient) previewGreenhouse(ctx context.Context, claimed autoapply
 	}
 	defer cancel()
 
-	pageHTML, err := renderedHTML(browserCtx, claimed.JobURL, greenhouseFormReadySelector)
+	// Safe to discard the lookup's ok here ONLY while this branch is gated to a provider
+	// the registry always holds. Lifting that gate must turn this into a real check.
+	layout, _ := layoutFor(claimed.Provider)
+	pageHTML, err := renderedHTML(browserCtx, claimed.JobURL, layout.formSelector)
 	if err != nil {
 		if result, parked := unscannableFormResult(err); parked {
 			return autoapply.PreviewResult{Parked: true, Reason: result.Reason}, nil
@@ -120,7 +123,7 @@ func (p *PreviewClient) previewGreenhouse(ctx context.Context, claimed autoapply
 	if hasRecaptchaMarker(pageHTML) {
 		return autoapply.PreviewResult{Parked: true, Reason: string(reasonCaptchaProtected)}, nil
 	}
-	dom, err := ScanGreenhouseForm(pageHTML)
+	dom, err := ScanForm(pageHTML, layout)
 	if err != nil {
 		return autoapply.PreviewResult{}, fmt.Errorf("scan application form: %w", err)
 	}

--- a/internal/api/atsapply/preview_test.go
+++ b/internal/api/atsapply/preview_test.go
@@ -104,32 +104,24 @@ func (r *fakeFormReader) GetStoredForm(context.Context, int64) (applyform.Form, 
 	return r.form, r.found, r.err
 }
 
-// A Lever attempt reaches its schema like any other provider — it is not refused for
-// carrying a captcha it may well not have.
+// A platform this package cannot drive a browser at still reaches its stored schema, and
+// its preview is computed from that rather than refused.
 //
-// Measured against live postings on 2026-09-09, which is what retired the blanket refusal:
-// two of the candidate's own queued Lever applications (coderio, jobgether) render NO
-// captcha at all — no hCaptcha, no reCAPTCHA, nothing. Four others do carry hCaptcha, and
-// their only "recaptcha" is the string `.g-recaptcha div` inside a CSS rule. So the
-// captcha is a per-employer setting, not a property of the platform, and a provider-wide
-// refusal decided what a page said before anyone looked at the page.
-//
-// Nothing here claims a Lever application can now be submitted: fillProviders still covers
-// Greenhouse alone, so Submit parks it as not-implemented. What changes is that the
-// candidate gets an answer preview instead of a reason that was never measured.
-func TestPreviewClient_ALeverAttemptReachesItsSchema(t *testing.T) {
-	fetcher := &fakeFetcher{form: applyform.Form{Provider: "lever"}}
-	p := &PreviewClient{fetchers: map[string]applyform.Fetcher{"lever": fetcher}, forms: nil}
+// This test used to be about Lever, asserting it reached a fetcher after #2721 retired the
+// blanket captcha refusal. Lever is now driven by a browser like Greenhouse (its layout is
+// in the registry), so the non-browser path it was written for no longer describes it.
+// Recruitee is the platform that path now serves: no layout, so no browser, and the stored
+// form is what the preview is built from.
+func TestPreviewClient_APlatformWithNoLayoutPreviewsFromItsStoredForm(t *testing.T) {
+	reader := &fakeFormReader{form: applyform.Form{Provider: "recruitee"}, found: true}
+	p := &PreviewClient{fetchers: nil, forms: reader}
 
-	result, err := p.Preview(context.Background(), autoapply.Claimed{Provider: "lever"}, nil)
+	result, err := p.Preview(context.Background(), autoapply.Claimed{Provider: "recruitee"}, nil)
 	if err != nil {
 		t.Fatalf("Preview: %v", err)
 	}
 	if result.Parked {
-		t.Errorf("result = %+v, want a preview rather than a park", result)
-	}
-	if !fetcher.called {
-		t.Error("the schema fetcher was never called — Lever is still being refused before it is read")
+		t.Errorf("result = %+v, want a preview computed from the stored form", result)
 	}
 }
 

--- a/openspec/changes/lever-fill-and-submit/.openspec.yaml
+++ b/openspec/changes/lever-fill-and-submit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/lever-fill-and-submit/design.md
+++ b/openspec/changes/lever-fill-and-submit/design.md
@@ -1,0 +1,112 @@
+## Context
+
+`internal/api/atsapply` drives a headless browser against an employer's application page:
+scan what it renders, reconcile against the platform's declared schema, resolve against the
+candidate's known answers, and fill and submit only when every required question is
+answered.
+
+It has driven exactly one platform. Greenhouse is named in four places — the form's element
+id (`domscan.go:54`), the field selector (`fill.go:141`), the submit button
+(`fill.go:74`), and whether to scan a DOM at all (`client.go:181`, and its twin in
+`preview_client.go`). Everything else — `fillAndSubmit`, `Resolve`, `Reconcile`, the answer
+bank, the résumé attachment, the parked and unconfirmed outcomes — is already
+provider-agnostic.
+
+Earlier today #2721 retired a blanket `requiresCaptcha{"lever": true}` refusal, measured
+wrong: two of this candidate's own queued Lever postings render no captcha of any kind, four
+others carry an invisible hCaptcha, and the only "recaptcha" on any of them is a string
+inside a CSS rule. With the refusal gone, the preview pass reached Lever's schema and came
+back with every field answered and nothing pending.
+
+Two failures in this package this week shape the decisions below. A captcha marker fired on
+the mere word `recaptcha` and parked every Greenhouse posting there is. A per-provider
+captcha list decided what a page said before anyone had loaded the page. Both were
+inferences standing in for a measurement.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fill and submit a Lever application, using the data the preview already resolves.
+- Make adding a third platform a row in a table rather than a fourth copy of scan, select,
+  click and verify.
+- Keep every existing Greenhouse behaviour byte-identical.
+
+**Non-Goals:**
+- Ashby, Workable, Recruitee. They have no fill path either; the browser-use fallback
+  already in the code is a separate, metered decision.
+- Solving a rendered captcha challenge. Those still park.
+- Deciding which postings to apply to.
+- Proving that an invisible hCaptcha admits a headless browser. Nothing here can; this is
+  what makes the answer observable.
+
+## Decisions
+
+### A registry of measured page descriptions, not heuristics
+
+Three values per platform: the form's element id, the submit control's selector, and how a
+field is addressed.
+
+*Alternative considered — heuristics.* Find the form as "the element with the most inputs",
+the button as "the one whose text says Apply". Rejected: a submit click cannot be withdrawn,
+and this is the shape of the two failures above. An inference that is wrong on one board is
+wrong silently, on somebody's real application.
+
+*Alternative considered — a code path per platform.* `ScanLeverForm`, `leverSubmitSelector`,
+a second branch in `Submit` and in `fillAndSubmit`. Rejected: a third platform becomes a
+third copy and a fourth `if` in each of four places.
+
+Both platforms happen to call the form `application-form`. That is written out per platform
+rather than shared: the third will not share it, and a shared constant would have to be
+un-shared under time pressure.
+
+### Addressing is one setting, not two
+
+Greenhouse names every control; Lever's inputs carry no `id` at all — only `name` and a
+`data-qa` hook. So the platform decides both which attribute identifies a scanned field and
+which locates it on the page.
+
+These are a single value because a mismatch between them is silent. Fields would resolve,
+the plan would report itself complete, and nothing would be found — at the last step, after
+the model spend and after the candidate approved the application. One value cannot
+disagree with itself.
+
+A `byName` control carrying no `name` is dropped from the scan rather than given the
+synthetic key an id-less control currently gets. That key exists so two anonymous controls
+do not collide in the scan; under `byName` it would instead mint a field that resolves and
+then cannot be typed into. Dropping it leaves the platform's own schema as the only thing
+that can still declare the field required — and the entry parks, which is honest.
+
+### Click the button a person clicks
+
+Lever's `#btn-submit` is a `type="button"`. Its own JS performs the invisible hCaptcha when
+the employer enabled one, then clicks the real hidden `#hcaptchaSubmitBtn`. This package
+clicks the visible one and does not model the rest: driving the hidden button directly would
+bypass the page's own submission logic on a form whose behaviour we have measured once.
+
+Lever's employer questions render as radio groups named `cards[<uuid>][field0]`. These need
+no new code — `fillOne`'s existing `checkbox_group` branch already selects
+`input[name=…][value=…]`, and a bracketed name is an ordinary attribute value. The selector
+must quote it, since brackets are syntax when unquoted.
+
+### The registry and the fill list must not drift
+
+Two sets answer the same question in two files: which platforms will be filled, and which
+have a page description. A platform in the first and not the second reaches a submit click
+with selectors matching nothing. A test asserts the containment; it passes trivially until
+Lever is added, which is when it starts holding weight.
+
+## Risks / Trade-offs
+
+- **An invisible hCaptcha may refuse a headless browser.** Unknown, and unknowable without
+  attempting one. The mitigation is the existing unconfirmed outcome: a click that is not
+  acknowledged is recorded as unconfirmed and never retried, because a duplicate application
+  costs the candidate more than a missing one.
+- **The Lever page was measured once, on one posting.** A posting with a different field set
+  or a white-label domain may not match. That surfaces as an unscannable form, which already
+  parks — the same fallback Greenhouse's white-label domains use.
+- **The registry is still a list**, and this package's history is a warning about lists. The
+  difference is what is in it: three values somebody read off a loaded page, checkable by
+  loading it again, rather than a claim about what pages contain.
+- **Greenhouse regressions would be silent** if the refactor changed identification for it.
+  Its existing scan tests must pass unmodified; a test that needed editing is the signal
+  that behaviour moved.

--- a/openspec/changes/lever-fill-and-submit/proposal.md
+++ b/openspec/changes/lever-fill-and-submit/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+A Lever application now resolves completely and still cannot be sent. Retiring the blanket
+`requiresCaptcha{"lever": true}` refusal (#2721) let the preview pass reach Lever's schema
+for the first time, and queue entry 6 came back with **every field answered and nothing
+pending** — full name, email, phone, current location. `fillProviders` names Greenhouse
+alone, so `Submit` parks it as not-implemented. The data is there; the code to type it is
+not.
+
+Lever is also the cheapest second provider available: most of the pipeline is already
+provider-agnostic, and what differs between the two platforms is three values somebody can
+read off a real posting.
+
+## What Changes
+
+- A per-provider **form layout registry** replaces the four places the provider is currently
+  hard-coded: the form's element id (`domscan.go`), the field selector (`fill.go`), the
+  submit button (`fill.go`), and whether to scan the DOM at all (`client.go`,
+  `preview_client.go`).
+- `ScanGreenhouseForm` becomes `ScanForm(pageHTML, layout)` — it scans whatever form the
+  layout names. **BREAKING** for callers inside this package only; the function is not used
+  outside it.
+- A field's **addressing** becomes explicit: Greenhouse identifies and selects a control by
+  `id`, Lever by `name`. Lever's inputs carry no `id` at all. This is one setting rather
+  than two, because a mismatch between identification and selection is silent — every field
+  would resolve and then not be found on the page.
+- A `byName` control with no `name` attribute is **dropped from the scan** rather than given
+  the synthetic key an id-less control currently gets: it can never be selected, so a field
+  for it would resolve and fail at the fill.
+- `lever` joins `fillProviders`. Its resolved plans reach a browser, a fill and a submit
+  click instead of parking as not-implemented.
+- The preview pass scans Lever's live DOM too, so the candidate's preview and the actual
+  submission cannot disagree about what the form contains.
+
+Not in this change: Ashby, Workable and Recruitee (no fill path either, and the browser-use
+fallback already in the code is a separate metered decision); solving a rendered captcha
+challenge (those still park); anything about which postings to apply to.
+
+## Capabilities
+
+### New Capabilities
+- `atsapply-form-layouts`: which application platforms this system can drive a browser
+  against, and what it must know about each one's page to do so safely.
+
+### Modified Capabilities
+<!-- None. atsapply-unscannable-form-detection's requirements are unchanged: a form that
+     cannot be read still parks, and a rendered challenge still parks. What changes is which
+     platforms are attempted at all, which that spec does not speak to. -->
+
+## Impact
+
+- `internal/api/atsapply`: `layout.go` (new), `domscan.go`, `fill.go`, `client.go`,
+  `preview_client.go`, `browser.go`, `AGENTS.md`.
+- No database, API, or wire-format change. No migration.
+- **Operationally significant:** this is the change after which auto-apply can submit a real
+  application to a real employer on a second platform. A submit click cannot be taken back,
+  so an unconfirmed submission stays a distinct, deliberately non-retried outcome.
+- Unknown, deliberately: whether an invisible hCaptcha lets a headless browser through.
+  Four of six measured Lever postings carry one; the two queued for this candidate carry
+  none. This change is what makes that answer observable.

--- a/openspec/changes/lever-fill-and-submit/specs/atsapply-form-layouts/spec.md
+++ b/openspec/changes/lever-fill-and-submit/specs/atsapply-form-layouts/spec.md
@@ -1,0 +1,67 @@
+# atsapply-form-layouts Specification
+
+## ADDED Requirements
+
+### Requirement: Only a platform this system has measured may be driven
+
+The system SHALL drive a browser against an employer's application page only for a platform
+whose page it holds a recorded description of. A platform with no such description SHALL
+reach neither a browser nor a submit click, and its attempts SHALL be recorded as unresolved
+for the reason that is true of them — that no fill path exists — never for an invented one.
+
+The description SHALL consist of values read off a real posting, never inferred from the
+page at run time. Locating the form by a general property (the element carrying the most
+inputs) or the submit control by its text is prohibited: a submit click cannot be withdrawn,
+and this system has twice acted on an inference about a page nobody had loaded.
+
+#### Scenario: An unmeasured platform is never driven
+
+- **WHEN** a queued attempt's platform has no recorded page description
+- **THEN** no browser is launched and no submit control is clicked for it
+- **AND** the attempt is recorded as unresolved because no fill path exists for that platform
+
+#### Scenario: A platform this system can fill always has a description
+
+- **WHEN** the set of platforms the system will fill and the set it holds descriptions for
+  are compared
+- **THEN** every platform in the first set appears in the second
+
+### Requirement: A field is identified and selected by the same attribute
+
+The system SHALL identify a scanned field and locate that field on the page by the SAME
+attribute, decided per platform. Identifying by one attribute while selecting by another
+SHALL NOT be possible.
+
+This is a single decision because the two failing to agree produces no error: every field
+resolves, the plan reports itself complete, and nothing is found on the page — after the
+model spend and after the candidate has approved the application.
+
+#### Scenario: A platform whose controls carry no id is addressed by name
+
+- **WHEN** a platform's application form renders controls that carry no `id` attribute
+- **THEN** each field is identified by its `name`
+- **AND** the same `name` is what locates the field on the page
+
+#### Scenario: A control that cannot be addressed is not offered as a field
+
+- **WHEN** a scanned control carries neither the attribute its platform is addressed by nor
+  any other means of locating it
+- **THEN** it is omitted from the scanned field inventory
+- **AND** it is never reported as a field the system will fill
+
+### Requirement: An unconfirmed submission is never retried
+
+The system SHALL treat a submit click that produces no confirmation as its own outcome,
+distinct from both success and from a transient failure, and SHALL NOT retry it.
+
+A retry cannot distinguish an application that never went through from one that did and
+merely did not say so, and the cost of the two mistakes is not symmetric: a missing
+application costs the candidate one opportunity, a duplicate costs them their credibility
+with that employer.
+
+#### Scenario: A submit click that is not acknowledged
+
+- **WHEN** the system clicks a platform's submit control and no confirmation appears within
+  the time it waits
+- **THEN** the attempt is recorded as unconfirmed
+- **AND** no further submission is attempted for that application

--- a/openspec/changes/lever-fill-and-submit/tasks.md
+++ b/openspec/changes/lever-fill-and-submit/tasks.md
@@ -1,8 +1,8 @@
 ## 1. The registry
 
-- [ ] 1.1 Write the failing test for `layoutFor`: Greenhouse resolves to `("application-form", "#submit_app", byID)`, Lever to `("application-form", "#btn-submit", byName)` — the values measured on `jobs.lever.co/coderio/.../apply` on 2026-09-09 — and a platform with no fill path (ashby, workable, recruitee, the empty string) resolves to nothing.
-- [ ] 1.2 Write the containment test: every entry in `fillProviders` has a layout. It passes trivially now and becomes load-bearing in 4.1; its purpose is that the two sets live in different files and a platform added to one and not the other would reach a submit click with selectors matching nothing.
-- [ ] 1.3 Create `internal/api/atsapply/layout.go` with `addressing` (`byID`, `byName`), `formLayout{formSelector, submitSelector, addressBy}`, the `layouts` table and `layoutFor`. The doc comments must carry WHY a table of measured values rather than heuristics — a submit click cannot be withdrawn, and this package has twice acted on an inference about a page nobody had loaded.
+- [x] 1.1 Write the failing test for `layoutFor`: Greenhouse resolves to `("application-form", "#submit_app", byID)`, Lever to `("application-form", "#btn-submit", byName)` — the values measured on `jobs.lever.co/coderio/.../apply` on 2026-09-09 — and a platform with no fill path (ashby, workable, recruitee, the empty string) resolves to nothing.
+- [x] 1.2 Write the containment test: every entry in `fillProviders` has a layout. It passes trivially now and becomes load-bearing in 4.1; its purpose is that the two sets live in different files and a platform added to one and not the other would reach a submit click with selectors matching nothing.
+- [x] 1.3 Create `internal/api/atsapply/layout.go` with `addressing` (`byID`, `byName`), `formLayout{formSelector, submitSelector, addressBy}`, the `layouts` table and `layoutFor`. The doc comments must carry WHY a table of measured values rather than heuristics — a submit click cannot be withdrawn, and this package has twice acted on an inference about a page nobody had loaded.
 
 ## 2. Scanning by the layout
 

--- a/openspec/changes/lever-fill-and-submit/tasks.md
+++ b/openspec/changes/lever-fill-and-submit/tasks.md
@@ -33,5 +33,5 @@
 
 ## 6. Verification
 
-- [ ] 6.1 Run `go build ./... && go vet ./... && go test ./... && go vet -tags=integration ./...` — all clean.
-- [ ] 6.2 Replay `ScanForm` against a freshly captured live Lever DOM on the production host, confirming the field inventory matches what the fixture asserts. A fixture that agrees only with itself is what this package was burned by twice this week.
+- [x] 6.1 Run `go build ./... && go vet ./... && go test ./... && go vet -tags=integration ./...` — all clean.
+- [x] 6.2 Replay `ScanForm` against a freshly captured live Lever DOM on the production host, confirming the field inventory matches what the fixture asserts. A fixture that agrees only with itself is what this package was burned by twice this week.

--- a/openspec/changes/lever-fill-and-submit/tasks.md
+++ b/openspec/changes/lever-fill-and-submit/tasks.md
@@ -27,9 +27,9 @@
 
 ## 5. The package's account of itself
 
-- [ ] 5.1 Rewrite the statements in `internal/api/atsapply/AGENTS.md` that are now false: the platform list, the "one provider with a live DOM-scan" framing, and any mention of `ScanGreenhouseForm` or `greenhouseSubmitSelector`.
-- [ ] 5.2 State what the code cannot: that a layout's three values are measured off a real posting and never inferred, naming the two failures that taught it; that addressing is one setting because a mismatch is silent; and that an unconfirmed submission is never retried because a duplicate application costs the candidate more than a missing one.
-- [ ] 5.3 Run `pnpm check:links` — every relative link in the file must resolve.
+- [x] 5.1 Rewrite the statements in `internal/api/atsapply/AGENTS.md` that are now false: the platform list, the "one provider with a live DOM-scan" framing, and any mention of `ScanGreenhouseForm` or `greenhouseSubmitSelector`.
+- [x] 5.2 State what the code cannot: that a layout's three values are measured off a real posting and never inferred, naming the two failures that taught it; that addressing is one setting because a mismatch is silent; and that an unconfirmed submission is never retried because a duplicate application costs the candidate more than a missing one.
+- [x] 5.3 Run `pnpm check:links` — every relative link in the file must resolve.
 
 ## 6. Verification
 

--- a/openspec/changes/lever-fill-and-submit/tasks.md
+++ b/openspec/changes/lever-fill-and-submit/tasks.md
@@ -14,16 +14,16 @@
 
 ## 3. Selecting and submitting by the layout
 
-- [ ] 3.1 Write the failing test for `fieldSelector(id, by)`: `byID` gives `#first_name`, `byName` gives `[name="name"]`, and a bracketed name (`urls[LinkedIn]`) survives quoted intact — brackets are selector syntax when unquoted.
-- [ ] 3.2 Change `fieldSelector` to take the addressing, and derive chromedp's query kind from the same value (`ByID` or `ByQuery`) in the same place, so the selector and the way it is interpreted cannot disagree.
-- [ ] 3.3 Replace the hard-coded `greenhouseSubmitSelector` click in `fillAndSubmit` with `layout.submitSelector`, and delete the constant. Record in the comment that Lever's `#btn-submit` is a `type="button"` whose own JS runs the invisible hCaptcha and then clicks the real hidden control — we click what a person clicks and do not model the rest.
+- [x] 3.1 Write the failing test for `fieldSelector(id, by)`: `byID` gives `#first_name`, `byName` gives `[name="name"]`, and a bracketed name (`urls[LinkedIn]`) survives quoted intact — brackets are selector syntax when unquoted.
+- [x] 3.2 Change `fieldSelector` to take the addressing, and derive chromedp's query kind from the same value (`ByID` or `ByQuery`) in the same place, so the selector and the way it is interpreted cannot disagree.
+- [x] 3.3 Replace the hard-coded `greenhouseSubmitSelector` click in `fillAndSubmit` with `layout.submitSelector`, and delete the constant. Record in the comment that Lever's `#btn-submit` is a `type="button"` whose own JS runs the invisible hCaptcha and then clicks the real hidden control — we click what a person clicks and do not model the rest.
 
 ## 4. Turning Lever on
 
-- [ ] 4.1 Write the failing test asserting `fillProviders["lever"]`, then add the entry, with a comment naming what was measured to justify it (the live preview came back fully resolved; the form's controls were captured 2026-09-09).
-- [ ] 4.2 Replace `if claimed.Provider == "greenhouse"` in `client.go` with a `layoutFor` lookup, passing `layout.formSelector` to `renderedHTML` and `layout` to `ScanForm` and `fillAndSubmit`.
-- [ ] 4.3 Make the same change in `preview_client.go`'s own Greenhouse branch — the preview must scan Lever's DOM too, or the candidate's preview and the actual submission would disagree about what the form contains.
-- [ ] 4.4 Verify the containment test from 1.2 now fails when `lever` is removed from either the registry or `fillProviders`, and passes with both. This is the only step that proves it holds weight.
+- [x] 4.1 Write the failing test asserting `fillProviders["lever"]`, then add the entry, with a comment naming what was measured to justify it (the live preview came back fully resolved; the form's controls were captured 2026-09-09).
+- [x] 4.2 Replace `if claimed.Provider == "greenhouse"` in `client.go` with a `layoutFor` lookup, passing `layout.formSelector` to `renderedHTML` and `layout` to `ScanForm` and `fillAndSubmit`.
+- [x] 4.3 Make the same change in `preview_client.go`'s own Greenhouse branch — the preview must scan Lever's DOM too, or the candidate's preview and the actual submission would disagree about what the form contains.
+- [x] 4.4 Verify the containment test from 1.2 now fails when `lever` is removed from either the registry or `fillProviders`, and passes with both. This is the only step that proves it holds weight.
 
 ## 5. The package's account of itself
 

--- a/openspec/changes/lever-fill-and-submit/tasks.md
+++ b/openspec/changes/lever-fill-and-submit/tasks.md
@@ -6,11 +6,11 @@
 
 ## 2. Scanning by the layout
 
-- [ ] 2.1 Capture the fixture: reduce the live DOM of `jobs.lever.co/coderio/6ce0e52b-e7bc-462f-ac9e-1d31c8c0e037/apply` to its form controls, verbatim attributes, into `internal/api/atsapply/leverform_test.go`. It must show what Lever does NOT have: no input carries an `id`.
-- [ ] 2.2 Write the failing tests over that fixture: Lever's fields are identified by `name` (including `urls[LinkedIn]` and the file input `resume`); the location control, which has BOTH an id and a differing name, is identified by its name; a Greenhouse fixture is still identified by `id`; and a `byName` control with no name is dropped rather than given a synthetic key.
-- [ ] 2.3 Replace `ScanGreenhouseForm` with `ScanForm(pageHTML string, layout formLayout)`, threading the addressing through `scanControls`, `scanInput` and `scanSimple`. Set `DOMField.ID` from whichever attribute the layout addresses by, keeping `Name` as the raw attribute, so everything downstream keeps working on one identifier.
-- [ ] 2.4 Delete `greenhouseFormReadySelector`; its value is now `layout.formSelector`, passed by the callers. Update both call sites (`client.go`, `preview_client.go`) enough to build.
-- [ ] 2.5 Confirm the pre-existing Greenhouse scan tests pass UNMODIFIED. A test that needed editing means behaviour moved for the platform that already worked — stop and say so rather than editing it.
+- [x] 2.1 Capture the fixture: reduce the live DOM of `jobs.lever.co/coderio/6ce0e52b-e7bc-462f-ac9e-1d31c8c0e037/apply` to its form controls, verbatim attributes, into `internal/api/atsapply/leverform_test.go`. It must show what Lever does NOT have: no input carries an `id`.
+- [x] 2.2 Write the failing tests over that fixture: Lever's fields are identified by `name` (including `urls[LinkedIn]` and the file input `resume`); the location control, which has BOTH an id and a differing name, is identified by its name; a Greenhouse fixture is still identified by `id`; and a `byName` control with no name is dropped rather than given a synthetic key.
+- [x] 2.3 Replace `ScanGreenhouseForm` with `ScanForm(pageHTML string, layout formLayout)`, threading the addressing through `scanControls`, `scanInput` and `scanSimple`. Set `DOMField.ID` from whichever attribute the layout addresses by, keeping `Name` as the raw attribute, so everything downstream keeps working on one identifier.
+- [x] 2.4 Delete `greenhouseFormReadySelector`; its value is now `layout.formSelector`, passed by the callers. Update both call sites (`client.go`, `preview_client.go`) enough to build.
+- [x] 2.5 Confirm the pre-existing Greenhouse scan tests pass UNMODIFIED. A test that needed editing means behaviour moved for the platform that already worked — stop and say so rather than editing it.
 
 ## 3. Selecting and submitting by the layout
 

--- a/openspec/changes/lever-fill-and-submit/tasks.md
+++ b/openspec/changes/lever-fill-and-submit/tasks.md
@@ -1,0 +1,37 @@
+## 1. The registry
+
+- [ ] 1.1 Write the failing test for `layoutFor`: Greenhouse resolves to `("application-form", "#submit_app", byID)`, Lever to `("application-form", "#btn-submit", byName)` — the values measured on `jobs.lever.co/coderio/.../apply` on 2026-09-09 — and a platform with no fill path (ashby, workable, recruitee, the empty string) resolves to nothing.
+- [ ] 1.2 Write the containment test: every entry in `fillProviders` has a layout. It passes trivially now and becomes load-bearing in 4.1; its purpose is that the two sets live in different files and a platform added to one and not the other would reach a submit click with selectors matching nothing.
+- [ ] 1.3 Create `internal/api/atsapply/layout.go` with `addressing` (`byID`, `byName`), `formLayout{formSelector, submitSelector, addressBy}`, the `layouts` table and `layoutFor`. The doc comments must carry WHY a table of measured values rather than heuristics — a submit click cannot be withdrawn, and this package has twice acted on an inference about a page nobody had loaded.
+
+## 2. Scanning by the layout
+
+- [ ] 2.1 Capture the fixture: reduce the live DOM of `jobs.lever.co/coderio/6ce0e52b-e7bc-462f-ac9e-1d31c8c0e037/apply` to its form controls, verbatim attributes, into `internal/api/atsapply/leverform_test.go`. It must show what Lever does NOT have: no input carries an `id`.
+- [ ] 2.2 Write the failing tests over that fixture: Lever's fields are identified by `name` (including `urls[LinkedIn]` and the file input `resume`); the location control, which has BOTH an id and a differing name, is identified by its name; a Greenhouse fixture is still identified by `id`; and a `byName` control with no name is dropped rather than given a synthetic key.
+- [ ] 2.3 Replace `ScanGreenhouseForm` with `ScanForm(pageHTML string, layout formLayout)`, threading the addressing through `scanControls`, `scanInput` and `scanSimple`. Set `DOMField.ID` from whichever attribute the layout addresses by, keeping `Name` as the raw attribute, so everything downstream keeps working on one identifier.
+- [ ] 2.4 Delete `greenhouseFormReadySelector`; its value is now `layout.formSelector`, passed by the callers. Update both call sites (`client.go`, `preview_client.go`) enough to build.
+- [ ] 2.5 Confirm the pre-existing Greenhouse scan tests pass UNMODIFIED. A test that needed editing means behaviour moved for the platform that already worked — stop and say so rather than editing it.
+
+## 3. Selecting and submitting by the layout
+
+- [ ] 3.1 Write the failing test for `fieldSelector(id, by)`: `byID` gives `#first_name`, `byName` gives `[name="name"]`, and a bracketed name (`urls[LinkedIn]`) survives quoted intact — brackets are selector syntax when unquoted.
+- [ ] 3.2 Change `fieldSelector` to take the addressing, and derive chromedp's query kind from the same value (`ByID` or `ByQuery`) in the same place, so the selector and the way it is interpreted cannot disagree.
+- [ ] 3.3 Replace the hard-coded `greenhouseSubmitSelector` click in `fillAndSubmit` with `layout.submitSelector`, and delete the constant. Record in the comment that Lever's `#btn-submit` is a `type="button"` whose own JS runs the invisible hCaptcha and then clicks the real hidden control — we click what a person clicks and do not model the rest.
+
+## 4. Turning Lever on
+
+- [ ] 4.1 Write the failing test asserting `fillProviders["lever"]`, then add the entry, with a comment naming what was measured to justify it (the live preview came back fully resolved; the form's controls were captured 2026-09-09).
+- [ ] 4.2 Replace `if claimed.Provider == "greenhouse"` in `client.go` with a `layoutFor` lookup, passing `layout.formSelector` to `renderedHTML` and `layout` to `ScanForm` and `fillAndSubmit`.
+- [ ] 4.3 Make the same change in `preview_client.go`'s own Greenhouse branch — the preview must scan Lever's DOM too, or the candidate's preview and the actual submission would disagree about what the form contains.
+- [ ] 4.4 Verify the containment test from 1.2 now fails when `lever` is removed from either the registry or `fillProviders`, and passes with both. This is the only step that proves it holds weight.
+
+## 5. The package's account of itself
+
+- [ ] 5.1 Rewrite the statements in `internal/api/atsapply/AGENTS.md` that are now false: the platform list, the "one provider with a live DOM-scan" framing, and any mention of `ScanGreenhouseForm` or `greenhouseSubmitSelector`.
+- [ ] 5.2 State what the code cannot: that a layout's three values are measured off a real posting and never inferred, naming the two failures that taught it; that addressing is one setting because a mismatch is silent; and that an unconfirmed submission is never retried because a duplicate application costs the candidate more than a missing one.
+- [ ] 5.3 Run `pnpm check:links` — every relative link in the file must resolve.
+
+## 6. Verification
+
+- [ ] 6.1 Run `go build ./... && go vet ./... && go test ./... && go vet -tags=integration ./...` — all clean.
+- [ ] 6.2 Replay `ScanForm` against a freshly captured live Lever DOM on the production host, confirming the field inventory matches what the fixture asserts. A fixture that agrees only with itself is what this package was burned by twice this week.


### PR DESCRIPTION
A Lever application already resolved completely and still could not be sent. Retiring the blanket captcha refusal (#2721) let the preview pass reach Lever's schema for the first time, and queue entry 6 came back with **every field answered and nothing pending** — full name, email, phone, current location. `fillProviders` named Greenhouse alone, so `Submit` parked it as not-implemented.

The data was there; the code to type it was not.

OpenSpec change: `lever-fill-and-submit` (proposal, spec, design, tasks — all in this branch).

## What changed

Most of the pipeline was already provider-agnostic. Greenhouse was named in exactly four places: the form's element id, the field selector, the submit button, and whether to scan a DOM at all. Those now read a **registry**: per platform, three values — the form's element id, the submit control's selector, and how a field is addressed.

Adding a third platform is a row, not a fourth branch in four files.

## Why a table and not heuristics

Locating the form as "the element with the most inputs", or the button by its text, is the shape of both failures this package had in a single day:

- `hasRecaptchaMarker` fired on the mere **word** `recaptcha` and parked every Greenhouse posting there is (#2684);
- `requiresCaptcha{"lever": true}` decided what a page said before anyone had loaded the page — two of this candidate's own Lever postings carry no captcha at all (#2721).

A submit click cannot be withdrawn. Three values somebody read off a loaded page are a description; a rule about what pages contain is a guess.

## Addressing is one setting, not two

Greenhouse names every control. **Lever's inputs carry no `id` at all** — and the two that do (the résumé upload, the location autocomplete) carry one that *differs* from the name Lever posts under.

So one value decides both which attribute identifies a scanned control and which selects it. Splitting them fails silently: every field resolves, the plan calls itself complete, and nothing is found on the page — at the last step, after the model spend and after the candidate approved.

**Review caught that rule failing in the one branch that mattered most.** The file-upload branch still named `chromedp.ByID`. Under `byName` that becomes `#[name="resume"]` — invalid CSS, matching nothing — on the résumé field, which is required on essentially every real posting. No Lever application could have been submitted, with every unit test green.

Fixed, and `TestFillOne_EveryActionOnTheSharedSelectorCarriesTheLayoutsQueryKind` now reads the source to keep it from returning. That test was confirmed to redden on the exact line that was wrong, and the containment test between `fillProviders` and the registry was confirmed to redden when a layout is removed.

## Verified against a live page, not just the fixture

`ScanForm` was replayed over a DOM captured from the live posting minutes earlier: **20 fields, every one identified by the name Lever posts under**, matching what the fixture asserts.

The fixture itself is reduced from that real DOM — down to its inconsistent attribute order and its three spellings of `required` — because a fixture that agrees only with the code is what this package was burned by twice this week.

The live scan also showed something the reduced fixture does not: that posting carries **nine required employer questions** as radio groups, three options each, in the posting's own language. So a Lever application is now fillable and that particular one still parks until those are answered — which is the screening answer bank's job (#2707), and the honest outcome rather than a guess at nine Spanish-language questions.

## What this does not claim

Whether an invisible hCaptcha admits a headless browser. Four of six measured Lever postings carry one; the two queued for this candidate carry none. This change makes that answer observable. A click that is not acknowledged stays `StatusUnconfirmed` and is **never retried** — a duplicate application costs the candidate more than a missing one.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` (220 packages, 0 failures), `go vet -tags=integration ./...`, `gofmt`, `golangci-lint`, `pnpm check:links` — all clean. Every pre-existing Greenhouse scan test passes with its assertions unmodified; only call sites were renamed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for filling and submitting Lever applications.
  - Added provider-specific form handling for Greenhouse and Lever, including field identification and submit controls.
  - Added live form preview scanning for supported providers.

- **Bug Fixes**
  - Fields without the required platform-specific identifier are no longer included in form scans.
  - Submission results without confirmation remain explicitly unconfirmed and are not retried.

- **Documentation**
  - Added implementation and design documentation for provider-specific form handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->