### PR TITLE
Document Bifrost, Langfuse, and Prometheus/Grafana in the README's tech stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,11 @@ which draw on AI credits.
 - **[sqlc](https://sqlc.dev/)** — type-safe DB access from SQL (no ORM)
 - **[Meilisearch](https://www.meilisearch.com/)** — full-text and faceted job search
 - **[langchaingo](https://github.com/tmc/langchaingo)** — LLM access over any OpenAI-compatible endpoint (no vendor baked in)
+- **[Bifrost](https://github.com/maximhq/bifrost)** — LLM gateway: per-user virtual keys, cross-provider fallback, spend tracking
+- **[Langfuse](https://langfuse.com/)** — LLM call tracing and observability
 - **[SvelteKit](https://kit.svelte.dev/) 2** (Svelte 5 runes) + **Tailwind 4** — the server-rendered frontend under `web/`
 - **Redis** — rate limiting and realtime fan-out · **S3-compatible object storage** — CVs, headshots, previews
+- **[Prometheus](https://prometheus.io/)** (via the node_exporter textfile collector) + **[Grafana](https://grafana.com/)** — metrics and dashboards for the ingest/LLM infrastructure
 - **Docker Compose** — local development
 
 ## Quick start


### PR DESCRIPTION
## Summary
- Adds three entries already running in production but missing from the README's stack list: Bifrost (LLM gateway), Langfuse (LLM tracing), Prometheus/Grafana (metrics and dashboards).

## Test plan
- Docs-only change; no functional testing needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Stack documentation to include Bifrost for LLM gateway services, Langfuse for tracing and observability, and Prometheus/Grafana for infrastructure metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->