### PR TITLE
Stop reading a stylesheet rule as a captcha

### DIFF
--- a/internal/api/atsapply/browser.go
+++ b/internal/api/atsapply/browser.go
@@ -177,16 +177,26 @@ var recaptchaChallengeFrames = []string{
 // evidence that a page's reCAPTCHA is one nobody has to pass.
 const recaptchaInvisibleBadge = "grecaptcha-badge"
 
-// recaptchaWidgetMarkers are the footprints of a reCAPTCHA widget being mounted at all: the
-// checkbox/badge iframe, and the widget element's own class before the script replaces it.
-// Matched with the class's delimiter attached so `g-recaptcha-response` — the hidden token
-// field EVERY reCAPTCHA page carries, invisible ones included — is not read as a widget.
+// recaptchaWidgetMarkers is the footprint of a reCAPTCHA widget being MOUNTED: the iframe
+// Google injects for the checkbox and for the invisible badge alike. Both URL shapes,
+// classic and Enterprise.
+//
+// The widget's own class is deliberately NOT here, and the reason is a defect this list
+// already caused. It used to carry `g-recaptcha"`, `g-recaptcha'` and `g-recaptcha ` — the
+// class with a delimiter attached, so that `g-recaptcha-response` (the hidden token field
+// every reCAPTCHA page has) would not match. But a CSS SELECTOR carries a delimiter too,
+// and Lever's own stylesheet ships `.page-centered,.g-recaptcha div,.h-captcha-spacing {…}`
+// on every posting. So a page with no reCAPTCHA of any kind — no iframe, no badge, nothing
+// but that one styling rule — was read as challenge-protected, and it parked a real,
+// fully-resolved application the candidate had already approved (freehire, 2026-09-09).
+//
+// Reading a class name out of page text cannot tell a rule that STYLES an element from the
+// element. An iframe URL can only be there because the script put it there, which is why
+// this list is iframes alone. Nothing is lost: a rendered widget always mounts an anchor
+// iframe — that is what a live capture established when this function was first narrowed.
 var recaptchaWidgetMarkers = []string{
 	"recaptcha/api2/anchor",
 	"recaptcha/enterprise/anchor",
-	`g-recaptcha"`,
-	`g-recaptcha'`,
-	"g-recaptcha ",
 }
 
 // hasRecaptchaMarker reports whether pageHTML carries a reCAPTCHA CHALLENGE — something a

--- a/internal/api/atsapply/browser_test.go
+++ b/internal/api/atsapply/browser_test.go
@@ -109,7 +109,45 @@ func TestHasRecaptchaMarker_RenderedChallengeWidgetIsAChallenge(t *testing.T) {
 	if !hasRecaptchaMarker(whitelabelFormWithRecaptchaHTML) {
 		t.Error("hasRecaptchaMarker = false for a rendered reCAPTCHA anchor iframe, want true")
 	}
-	if !hasRecaptchaMarker(`<div class="g-recaptcha" data-sitekey="abc"></div>`) {
-		t.Error("hasRecaptchaMarker = false for an explicit g-recaptcha widget, want true")
+	// A bare `<div class="g-recaptcha">` with no iframe is deliberately NOT a challenge.
+	// At that point the script has not run and nothing is being asked; once it does, it
+	// mounts the anchor iframe above. Matching the class instead is what read Lever's own
+	// stylesheet as a captcha and parked a real application — see
+	// TestHasRecaptchaMarker_AStylesheetRuleIsNotAChallenge.
+	//
+	// The trade is deliberate and asymmetric: a missed challenge costs one unconfirmed
+	// submission, which is already a distinct, non-retried outcome. A false one costs the
+	// candidate an application they had approved, silently, forever.
+	if hasRecaptchaMarker(`<div class="g-recaptcha" data-sitekey="abc"></div>`) {
+		t.Error("hasRecaptchaMarker = true for a widget the script has not mounted yet, want false")
+	}
+}
+
+// A CSS rule that STYLES a reCAPTCHA widget is not a widget.
+//
+// Verbatim from the live DOM of jobs.lever.co/jobgether/08a82436-.../apply, 2026-09-09 —
+// the same page a live capture found carries no bframe, no badge and no anchor iframe:
+// nothing of reCAPTCHA is on it at all except this one stylesheet line.
+//
+// It parked a real, fully-resolved application the candidate had already approved. The
+// marker looked for the widget's class with a delimiter attached, on the reasoning that
+// `g-recaptcha-response` (the hidden token field) must not match — but a CSS selector
+// carries a delimiter too. Reading a class name out of page text cannot tell a rule that
+// styles an element from the element.
+const leverStylesheetMentioningRecaptchaHTML = `
+<html><head><style>
+.page-full-width {width: 100%;}
+.page-centered,.g-recaptcha div,.h-captcha-spacing {display: block; margin: 0 auto;}
+</style></head><body>
+<form id="application-form">
+  <input type="text" name="name" required>
+</form>
+</body></html>
+`
+
+func TestHasRecaptchaMarker_AStylesheetRuleIsNotAChallenge(t *testing.T) {
+	if hasRecaptchaMarker(leverStylesheetMentioningRecaptchaHTML) {
+		t.Error("hasRecaptchaMarker = true for a page whose only mention of reCAPTCHA is a CSS rule, " +
+			"want false — it carries no widget, no badge and no challenge iframe")
 	}
 }


### PR DESCRIPTION
A real, fully-resolved Lever application **the candidate had already approved** was parked as `form_captcha_protected`.

A live capture of that same page finds no reCAPTCHA of any kind — no challenge iframe, no badge, no anchor iframe. The only mention of it anywhere on the page is one line of CSS, which Lever ships on every posting:

```css
.page-centered,.g-recaptcha div,.h-captcha-spacing {display: block; margin: 0 auto;}
```

## Why it matched

The marker list carried the widget's class with a delimiter attached — `g-recaptcha"`, `g-recaptcha'`, `g-recaptcha ` — so that `g-recaptcha-response`, the hidden token field every reCAPTCHA page has, would not match.

**A CSS selector carries a delimiter too.**

This is the same defect this same function had two days ago, one level finer: then it fired on the mere *word* `recaptcha` and parked every Greenhouse posting there is (#2684). Reading a class name out of page text cannot tell a rule that *styles* an element from the element.

## The fix

The class goes. The marker is iframe URLs alone — an iframe can only be in the DOM because the script put it there.

Nothing is lost: a rendered widget always mounts an anchor iframe, which is what a live capture established when this function was first narrowed.

A bare `<div class="g-recaptcha">` with no iframe is now explicitly **not** a challenge — at that point the script has not run and nothing is being asked.

## The trade, stated plainly

It is asymmetric, and that is the reason for it:

- a **missed** challenge costs one unconfirmed submission — already a distinct, never-retried outcome;
- a **false** one costs the candidate an application they had approved, silently, forever.

## Verification

Replayed against three live pages:

| Page | Verdict |
|---|---|
| jobgether (Lever) | no captcha → passes through |
| bluelightconsulting (Lever) | no captcha → passes through |
| garnerhealth (Greenhouse) | invisible reCAPTCHA → passes through |

Test-first: the fixture is the CSS rule verbatim from the live DOM. `go test ./...`, `go vet ./...`, `gofmt`, `golangci-lint` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application form handling by preventing CSS-only references to reCAPTCHA from being mistaken for an active challenge.
  - Continued recognizing genuinely rendered reCAPTCHA challenge iframes.
  - Reduced cases where valid, fillable applications could be incorrectly held for reCAPTCHA verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->