### PR TITLE
Stop an upgrade or downgrade from opening a second Stripe subscription

### DIFF
--- a/internal/api/handler/billing.go
+++ b/internal/api/handler/billing.go
@@ -183,7 +183,7 @@ func (h *billingHandlers) Checkout(c *fiber.Ctx) error {
 
 	// The price comes from the pricing page's monthly/annual choice. It is validated
 	// against the configured list inside the service — never trusted as sent.
-	url, err := h.billing.CheckoutURL(ctx, userID, c.Query("price"), discount)
+	url, applied, err := h.billing.CheckoutURL(ctx, userID, c.Query("price"), discount)
 	if err != nil {
 		// Either checkout is unconfigured, or the provider refused. Neither is something a
 		// candidate can act on, and a 404 lets the surface omit the offer rather than render
@@ -193,10 +193,12 @@ func (h *billingHandlers) Checkout(c *fiber.Ctx) error {
 	}
 	return c.JSON(fiber.Map{"data": fiber.Map{
 		"url": url,
-		// Which offer was applied, so the page can say so rather than leaving the buyer to
-		// work it out from the amount on the provider's page. Empty when there was none.
-		"discount_percent": discount.PercentOff,
-		"discount_source":  discount.Label,
+		// Which offer was actually APPLIED — not merely offered — so the page can say so
+		// rather than leaving the buyer to work it out from the amount on the provider's
+		// page. Empty when there was none, including when a tier change modified an existing
+		// subscription in place rather than opening a checkout: that path never applies one.
+		"discount_percent": applied.PercentOff,
+		"discount_source":  applied.Label,
 	}})
 }
 

--- a/internal/identity/billing/AGENTS.md
+++ b/internal/identity/billing/AGENTS.md
@@ -170,6 +170,16 @@ answer 404, and its worker exits without opening a connection.
 - **Checkout reuses a known customer.** A second purchase that created a second customer for
   one person would leave two subscriptions nobody sums.
 
+- **A tier change on a known customer reuses their existing subscription, never a second
+  Checkout Session.** `CheckoutURL` reads the customer's current subscriptions
+  (`decideCheckoutTarget`, in `entitlement.go`) and, if one already entitles them, calls
+  `client.updateSubscriptionPrice` to swap that subscription's item to the new price with
+  proration — it never opens a new Checkout Session for an existing subscriber. This is the
+  fix for a real production incident: before it existed, "Upgrade to Ultra" on an active Pro
+  subscriber opened a second, independent subscription, and both kept billing in parallel.
+  A failure reading the customer's current subscriptions fails the whole call rather than
+  falling back to a new checkout — falling back would silently recreate the bug.
+
 - **Absent credentials mean disabled, never an error.** `ConfigFromEnv` cannot fail and `New`
   cannot fail. `Enabled()` gates the subsystem; `CanCheckout()` additionally needs a site URL
   to return a buyer to, and is separate on purpose — subscriptions already sold keep
@@ -190,7 +200,9 @@ way the tests do not reproduce.
   id string with nothing to match on, and **`current_period_end` is on the item** — verified
   against a real subscription rather than a stub, which is the only way that one shows up.
 - Checkout: `POST /v1/checkout/sessions`, form-encoded. Management: `POST
-  /v1/billing_portal/sessions`, which returns a short-lived URL.
+  /v1/billing_portal/sessions`, which returns a short-lived URL. Changing an existing
+  subscription's price: `POST /v1/subscriptions/{id}` with `items[0][id]`, `items[0][price]`
+  and `proration_behavior`.
 - Delivery: unordered, duplicates possible, retried for up to three days; an endpoint the
   provider decides is broken can be disabled sooner than that.
 

--- a/internal/identity/billing/AGENTS.md
+++ b/internal/identity/billing/AGENTS.md
@@ -178,7 +178,16 @@ answer 404, and its worker exits without opening a connection.
   fix for a real production incident: before it existed, "Upgrade to Ultra" on an active Pro
   subscriber opened a second, independent subscription, and both kept billing in parallel.
   A failure reading the customer's current subscriptions fails the whole call rather than
-  falling back to a new checkout — falling back would silently recreate the bug.
+  falling back to a new checkout — falling back would silently recreate the bug. A
+  subscription carrying more than one item (the shape `billedSubscription`'s own comment
+  describes an upgrade through the provider's portal leaving behind) refuses rather than
+  guessing which item's price to replace — item order is not a documented guarantee, the same
+  reason `tierFirst` exists instead of trusting raw order. `updateSubscriptionPrice` carries a
+  fresh idempotency key per call, because it creates a proration invoice item and a low-level
+  HTTP retry replaying the same request must not bill it twice. `CheckoutURL`'s returned
+  `Discount` is what was actually APPLIED, never the one offered: an in-place update never
+  applies one, so its caller (the `/billing/checkout` handler) must not report a discount that
+  never touched the customer's bill.
 
 - **Absent credentials mean disabled, never an error.** `ConfigFromEnv` cannot fail and `New`
   cannot fail. `Enabled()` gates the subsystem; `CanCheckout()` additionally needs a site URL

--- a/internal/identity/billing/checkout_integration_test.go
+++ b/internal/identity/billing/checkout_integration_test.go
@@ -1,0 +1,174 @@
+//go:build integration
+
+// CheckoutURL end to end, against a real Postgres and a stubbed provider: the one piece of
+// the duplicate-subscription fix that the pure decideCheckoutTarget/updateSubscriptionPrice
+// unit tests cannot reach, because CheckoutURL itself needs *db.Queries (GetStripeCustomerID)
+// to even decide whether a customer is known. Run with:
+// go test -tags=integration ./internal/identity/billing/
+package billing
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// checkoutRouter dispatches the provider stub paths CheckoutURL can reach, recording which
+// ones were hit and what they carried — the assertion surface every test below reads.
+type checkoutRouter struct {
+	subscriptions http.HandlerFunc // GET /subscriptions
+
+	checkoutCalled bool
+	couponCalled   bool
+	updateCalled   bool
+	updatePath     string
+	updateForm     string
+}
+
+func (r *checkoutRouter) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		switch {
+		case req.URL.Path == "/subscriptions":
+			r.subscriptions(w, req)
+		case req.URL.Path == "/checkout/sessions":
+			r.checkoutCalled = true
+			_, _ = w.Write([]byte(`{"url":"https://checkout.stripe.com/c/pay/cs_test_123"}`))
+		case req.URL.Path == "/coupons":
+			r.couponCalled = true
+			_, _ = w.Write([]byte(`{"id":"co_test"}`))
+		case strings.HasPrefix(req.URL.Path, "/subscriptions/"):
+			r.updateCalled = true
+			r.updatePath = req.URL.Path
+			_ = req.ParseForm()
+			r.updateForm = req.Form.Encode()
+			_, _ = w.Write([]byte(`{"id":"sub_1"}`))
+		default:
+			_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+		}
+	}
+}
+
+// TestCheckoutURLUpdatesAnExistingSubscriptionInPlace is the fix's central guarantee: a
+// customer who already has an active Pro subscription and asks for Ultra gets that SAME
+// subscription changed in place, never a second Checkout Session. Against the pre-fix code
+// this assertion fails — createCheckoutSession is always called regardless of what the
+// customer already has.
+func TestCheckoutURLUpdatesAnExistingSubscriptionInPlace(t *testing.T) {
+	router := &checkoutRouter{
+		subscriptions: func(w http.ResponseWriter, _ *http.Request) {
+			until := time.Now().UTC().Add(30 * 24 * time.Hour)
+			_, _ = fmt.Fprintf(w, `{"data":[{"id":"sub_1","status":"active",`+
+				`"items":{"data":[{"id":"si_1","current_period_end":%d,"price":{"id":%q}}]}}]}`,
+				until.Unix(), proPrice)
+		},
+	}
+	s, pool := newTieredService(t, router.handler())
+	ctx := context.Background()
+
+	userID := insertUser(t, pool, "upgrader-inplace@example.com")
+	bindCustomer(t, pool, userID, "cus_inplace")
+
+	// A discount is offered but must never be applied to an in-place update — design.md's
+	// own stated Non-Goal — and the coupon endpoint must never even be called.
+	offered := Discount{PercentOff: 20, Label: "invite", Key: "k1"}
+	url, applied, err := s.CheckoutURL(ctx, userID, ultraPrice, offered)
+	if err != nil {
+		t.Fatalf("CheckoutURL: %v", err)
+	}
+
+	if router.checkoutCalled {
+		t.Fatal("a new Checkout Session was opened for a customer who already has an entitling subscription")
+	}
+	if router.couponCalled {
+		t.Fatal("a coupon was minted for an in-place update, which never applies a discount")
+	}
+	if !router.updateCalled {
+		t.Fatal("the existing subscription was never updated")
+	}
+	if router.updatePath != "/subscriptions/sub_1" {
+		t.Fatalf("updated path = %q, want /subscriptions/sub_1", router.updatePath)
+	}
+	if !strings.Contains(router.updateForm, "items%5B0%5D%5Bid%5D=si_1") ||
+		!strings.Contains(router.updateForm, "items%5B0%5D%5Bprice%5D="+ultraPrice) {
+		t.Fatalf("update form = %q, want item si_1 replaced with %s", router.updateForm, ultraPrice)
+	}
+	if url != s.cfg.ReturnURL() {
+		t.Fatalf("url = %q, want the return URL %q", url, s.cfg.ReturnURL())
+	}
+	if applied != (Discount{}) {
+		t.Fatalf("applied discount = %+v, want none — an in-place update never applies one", applied)
+	}
+}
+
+// TestCheckoutURLOpensACheckoutSessionForAKnownCustomerWithNoSubscription covers the
+// fallthrough: a bound Stripe customer (they have transacted before — a referral credit, a
+// lapsed subscription) who currently holds nothing entitling must still reach an ordinary
+// checkout, carrying whatever discount they were offered.
+func TestCheckoutURLOpensACheckoutSessionForAKnownCustomerWithNoSubscription(t *testing.T) {
+	router := &checkoutRouter{
+		subscriptions: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		},
+	}
+	s, pool := newTieredService(t, router.handler())
+	ctx := context.Background()
+
+	userID := insertUser(t, pool, "lapsed@example.com")
+	bindCustomer(t, pool, userID, "cus_lapsed")
+
+	offered := Discount{PercentOff: 20, Label: "invite", Key: "k2"}
+	url, applied, err := s.CheckoutURL(ctx, userID, proPrice, offered)
+	if err != nil {
+		t.Fatalf("CheckoutURL: %v", err)
+	}
+
+	if router.updateCalled {
+		t.Fatal("nothing was updated in place — there is no entitling subscription to update")
+	}
+	if !router.checkoutCalled {
+		t.Fatal("no Checkout Session was opened for a customer with no entitling subscription")
+	}
+	if !router.couponCalled {
+		t.Fatal("the offered discount was never minted as a coupon")
+	}
+	if url != "https://checkout.stripe.com/c/pay/cs_test_123" {
+		t.Fatalf("url = %q, want the Checkout Session URL", url)
+	}
+	if applied != offered {
+		t.Fatalf("applied discount = %+v, want the offered one %+v", applied, offered)
+	}
+}
+
+// TestCheckoutURLRefusesToGuessOnAnAmbiguousSubscription: a subscription already carrying an
+// item of each tier (the shape billedSubscription's own comment describes an upgrade through
+// the provider's portal leaving behind) must never have an item silently replaced by guess.
+func TestCheckoutURLRefusesToGuessOnAnAmbiguousSubscription(t *testing.T) {
+	router := &checkoutRouter{
+		subscriptions: func(w http.ResponseWriter, _ *http.Request) {
+			until := time.Now().UTC().Add(30 * 24 * time.Hour)
+			_, _ = fmt.Fprintf(w, `{"data":[{"id":"sub_both","status":"active","items":{"data":[`+
+				`{"id":"si_a","current_period_end":%d,"price":{"id":%q}},`+
+				`{"id":"si_b","current_period_end":%d,"price":{"id":%q}}]}}]}`,
+				until.Unix(), proPrice, until.Unix(), ultraPrice)
+		},
+	}
+	s, pool := newTieredService(t, router.handler())
+	ctx := context.Background()
+
+	userID := insertUser(t, pool, "ambiguous@example.com")
+	bindCustomer(t, pool, userID, "cus_ambiguous")
+
+	if _, _, err := s.CheckoutURL(ctx, userID, "price_pro_annual", Discount{}); err == nil {
+		t.Fatal("want an error refusing to guess which item to change, got nil")
+	}
+
+	if router.checkoutCalled {
+		t.Fatal("a second Checkout Session was opened instead of refusing")
+	}
+	if router.updateCalled {
+		t.Fatal("an item was updated despite the ambiguity")
+	}
+}

--- a/internal/identity/billing/checkout_integration_test.go
+++ b/internal/identity/billing/checkout_integration_test.go
@@ -142,6 +142,32 @@ func TestCheckoutURLOpensACheckoutSessionForAKnownCustomerWithNoSubscription(t *
 	}
 }
 
+// TestCheckoutURLFailsRatherThanTreatAFailedBindingReadAsUnbound guards a sibling of the
+// fix's central line (service.go's read of client.subscriberState): a failure reading
+// GetStripeCustomerID itself must not be treated as "no customer", which would open a
+// checkout that creates a second Stripe customer and a second subscription for someone who
+// already has both — reproducing the exact bug this method exists to prevent. A nonexistent
+// user id is what makes the underlying `:one` query fail deterministically, without needing
+// to fail the database connection itself.
+func TestCheckoutURLFailsRatherThanTreatAFailedBindingReadAsUnbound(t *testing.T) {
+	router := &checkoutRouter{
+		subscriptions: func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		},
+	}
+	s, _ := newTieredService(t, router.handler())
+	ctx := context.Background()
+
+	const nonexistentUserID = -1
+	if _, _, err := s.CheckoutURL(ctx, nonexistentUserID, proPrice, Discount{}); err == nil {
+		t.Fatal("want an error when the customer binding cannot be read, got nil")
+	}
+
+	if router.checkoutCalled {
+		t.Fatal("a checkout was opened despite the binding read failing — this is the bug this test guards")
+	}
+}
+
 // TestCheckoutURLRefusesToGuessOnAnAmbiguousSubscription: a subscription already carrying an
 // item of each tier (the shape billedSubscription's own comment describes an upgrade through
 // the provider's portal leaving behind) must never have an item silently replaced by guess.

--- a/internal/identity/billing/client.go
+++ b/internal/identity/billing/client.go
@@ -264,13 +264,18 @@ func (c *client) createCheckoutSession(ctx context.Context, userID int64, email,
 // proration_behavior is named explicitly rather than left to the provider's default: this is
 // the one place in the package that changes what an existing subscriber is charged mid-cycle,
 // and a future default change upstream must not alter that silently.
-func (c *client) updateSubscriptionPrice(ctx context.Context, subscriptionID, itemID, priceID string) error {
+//
+// idempotencyKey is required, unlike most reads in this file: this call creates a proration
+// invoice item, so a low-level HTTP retry of the same request (Go's transport can replay a
+// POST whose body is seekable, which url.Values.Encode()'s is) must not bill the same change
+// twice.
+func (c *client) updateSubscriptionPrice(ctx context.Context, subscriptionID, itemID, priceID, idempotencyKey string) error {
 	form := url.Values{}
 	form.Set("items[0][id]", itemID)
 	form.Set("items[0][price]", priceID)
 	form.Set("proration_behavior", "create_prorations")
 
-	return c.do(ctx, http.MethodPost, "/subscriptions/"+subscriptionID, form, "", nil)
+	return c.do(ctx, http.MethodPost, "/subscriptions/"+subscriptionID, form, idempotencyKey, nil)
 }
 
 // createPortalSession opens the provider's own subscription-management page for one

--- a/internal/identity/billing/client.go
+++ b/internal/identity/billing/client.go
@@ -128,13 +128,15 @@ func (c *client) do(ctx context.Context, method, path string, form url.Values, i
 // only one place would silently produce a subscription with no end.
 type stripeSubscriptionList struct {
 	Data []struct {
+		ID                string `json:"id"`
 		Status            string `json:"status"`
 		CurrentPeriodEnd  int64  `json:"current_period_end"`
 		CancelAt          int64  `json:"cancel_at"`
 		CancelAtPeriodEnd bool   `json:"cancel_at_period_end"`
 		Items             struct {
 			Data []struct {
-				CurrentPeriodEnd int64 `json:"current_period_end"`
+				ID               string `json:"id"`
+				CurrentPeriodEnd int64  `json:"current_period_end"`
 				Price            struct {
 					ID string `json:"id"`
 				} `json:"price"`
@@ -167,7 +169,7 @@ func (c *client) subscriberState(ctx context.Context, customerID string) (subscr
 
 	out := subscriber{Subscriptions: make([]subscription, 0, len(raw.Data))}
 	for _, s := range raw.Data {
-		sub := subscription{Status: s.Status}
+		sub := subscription{ID: s.ID, Status: s.Status}
 		if s.CancelAt > 0 {
 			sub.CancelAt = time.Unix(s.CancelAt, 0).UTC()
 		}
@@ -175,12 +177,19 @@ func (c *client) subscriberState(ctx context.Context, customerID string) (subscr
 		// The furthest item decides how far the subscription reaches: with items on
 		// different cycles, access should last as long as the longest of them.
 		periodEnd := s.CurrentPeriodEnd
-		for _, item := range s.Items.Data {
+		for i, item := range s.Items.Data {
 			if item.CurrentPeriodEnd > periodEnd {
 				periodEnd = item.CurrentPeriodEnd
 			}
 			if item.Price.ID != "" {
 				sub.PriceIDs = append(sub.PriceIDs, item.Price.ID)
+			}
+			if i == 0 {
+				// Every subscription this integration creates carries exactly one item (see
+				// createCheckoutSession), and an upgrade/downgrade replaces that item's price
+				// rather than adding a second one — so reading only the first item's id matches
+				// the one invariant this integration maintains.
+				sub.ItemID = item.ID
 			}
 		}
 		if periodEnd > 0 {
@@ -245,6 +254,23 @@ func (c *client) createCheckoutSession(ctx context.Context, userID int64, email,
 		return "", fmt.Errorf("billing: provider returned a checkout session with no URL")
 	}
 	return out.URL, nil
+}
+
+// updateSubscriptionPrice changes an existing subscription's item to a different price, with
+// proration. It is the upgrade/downgrade path, and it never creates a second subscription —
+// that is exactly the bug it exists to stop: before this existed, changing tier always opened
+// a new Checkout Session, leaving two subscriptions billing the same customer in parallel.
+//
+// proration_behavior is named explicitly rather than left to the provider's default: this is
+// the one place in the package that changes what an existing subscriber is charged mid-cycle,
+// and a future default change upstream must not alter that silently.
+func (c *client) updateSubscriptionPrice(ctx context.Context, subscriptionID, itemID, priceID string) error {
+	form := url.Values{}
+	form.Set("items[0][id]", itemID)
+	form.Set("items[0][price]", priceID)
+	form.Set("proration_behavior", "create_prorations")
+
+	return c.do(ctx, http.MethodPost, "/subscriptions/"+subscriptionID, form, "", nil)
 }
 
 // createPortalSession opens the provider's own subscription-management page for one

--- a/internal/identity/billing/client_test.go
+++ b/internal/identity/billing/client_test.go
@@ -17,7 +17,7 @@ const subscriptionsBody = `{
       "id": "sub_1",
       "status": "active",
       "cancel_at": null,
-      "items": { "data": [ { "current_period_end": 1790812800, "price": { "id": "price_pro_monthly" } } ] }
+      "items": { "data": [ { "id": "si_1", "current_period_end": 1790812800, "price": { "id": "price_pro_monthly" } } ] }
     }
   ]
 }`
@@ -64,6 +64,14 @@ func TestClientSubscriberState(t *testing.T) {
 	s := sub.Subscriptions[0]
 	if s.Status != "active" {
 		t.Errorf("status: got %q", s.Status)
+	}
+	// The subscription and (first) item id are what an upgrade or downgrade needs to name
+	// which subscription to modify in place, instead of opening a second one.
+	if s.ID != "sub_1" {
+		t.Errorf("subscription id: got %q", s.ID)
+	}
+	if s.ItemID != "si_1" {
+		t.Errorf("item id: got %q", s.ItemID)
 	}
 	// Read from the ITEM. The provider moved it there; a client reading only the top level
 	// gets zero, and a zero period end is what an earlier fallback turned into "forever".
@@ -185,6 +193,32 @@ func TestClientCheckoutNeverSendsCustomerCreation(t *testing.T) {
 		}
 		if strings.Contains(gotForm, "customer_creation") {
 			t.Fatalf("form %q sends customer_creation, which subscription mode refuses", gotForm)
+		}
+	}
+}
+
+// TestClientUpdateSubscriptionPrice guards the fix for freehire's duplicate-subscription
+// bug: an upgrade or downgrade must change the existing subscription's item, never open a
+// second subscription.
+func TestClientUpdateSubscriptionPrice(t *testing.T) {
+	var gotPath, gotForm string
+	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = r.ParseForm()
+		gotForm = r.Form.Encode()
+		_, _ = w.Write([]byte(`{"id":"sub_1"}`))
+	})
+
+	if err := c.updateSubscriptionPrice(context.Background(), "sub_1", "si_1", "price_ultra_monthly"); err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+
+	if gotPath != "/subscriptions/sub_1" {
+		t.Errorf("path: want /subscriptions/sub_1, got %q", gotPath)
+	}
+	for _, want := range []string{"items%5B0%5D%5Bid%5D=si_1", "items%5B0%5D%5Bprice%5D=price_ultra_monthly", "proration_behavior=create_prorations"} {
+		if !strings.Contains(gotForm, want) {
+			t.Errorf("form %q is missing %q", gotForm, want)
 		}
 	}
 }

--- a/internal/identity/billing/client_test.go
+++ b/internal/identity/billing/client_test.go
@@ -201,15 +201,16 @@ func TestClientCheckoutNeverSendsCustomerCreation(t *testing.T) {
 // bug: an upgrade or downgrade must change the existing subscription's item, never open a
 // second subscription.
 func TestClientUpdateSubscriptionPrice(t *testing.T) {
-	var gotPath, gotForm string
+	var gotPath, gotForm, gotIdempotencyKey string
 	c := testClient(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
+		gotIdempotencyKey = r.Header.Get("Idempotency-Key")
 		_ = r.ParseForm()
 		gotForm = r.Form.Encode()
 		_, _ = w.Write([]byte(`{"id":"sub_1"}`))
 	})
 
-	if err := c.updateSubscriptionPrice(context.Background(), "sub_1", "si_1", "price_ultra_monthly"); err != nil {
+	if err := c.updateSubscriptionPrice(context.Background(), "sub_1", "si_1", "price_ultra_monthly", "idem_key_1"); err != nil {
 		t.Fatalf("want no error, got %v", err)
 	}
 
@@ -220,6 +221,11 @@ func TestClientUpdateSubscriptionPrice(t *testing.T) {
 		if !strings.Contains(gotForm, want) {
 			t.Errorf("form %q is missing %q", gotForm, want)
 		}
+	}
+	// A proration-creating call must carry an idempotency key: a low-level HTTP retry of the
+	// same request must not create the same proration twice.
+	if gotIdempotencyKey != "idem_key_1" {
+		t.Errorf("idempotency key: want %q, got %q", "idem_key_1", gotIdempotencyKey)
 	}
 }
 

--- a/internal/identity/billing/entitlement.go
+++ b/internal/identity/billing/entitlement.go
@@ -24,6 +24,11 @@ type subscriber struct {
 // taking access away over a failed retry is the same mistake as ignoring a grace period.
 // `canceled`, `unpaid` and `incomplete` do not.
 type subscription struct {
+	// ID and ItemID name this subscription and its first item at the provider — what an
+	// upgrade or downgrade needs to modify it in place instead of opening a second
+	// subscription. Empty when the source is a fixture that never set them.
+	ID     string
+	ItemID string
 	Status string
 	// CurrentPeriodEnd is when the paid-for period runs out — the instant access should
 	// lapse if nothing renews it. The zero time means we could not read it, and every caller
@@ -161,6 +166,73 @@ func tierFirst(ids, tier []string) []string {
 		}
 	}
 	return out
+}
+
+// checkoutTarget is CheckoutURL's whole decision for one request: what to do with the price
+// the customer asked for, given what they already have.
+//
+// The zero value means "no entitling subscription exists — open a new Checkout Session",
+// exactly as CheckoutURL always did before this type existed.
+type checkoutTarget struct {
+	// SubscriptionID and ItemID name an existing subscription and its item to change in
+	// place. Set together; both empty (and AlreadyOnPrice false) means open a checkout.
+	SubscriptionID string
+	ItemID         string
+	// AlreadyOnPrice is true when the customer's current entitling subscription already
+	// carries the requested price. Nothing to do.
+	AlreadyOnPrice bool
+}
+
+// decideCheckoutTarget is the fix for freehire's duplicate-subscription bug, kept pure and
+// DB-free: before this existed, CheckoutURL always opened a new Checkout Session regardless
+// of what the customer already had, leaving two subscriptions billing them in parallel.
+//
+// It asks across BOTH configured price lists — a customer's current tier may be either —
+// for their single best-entitling subscription, reusing the same selection
+// bestEntitling/billedSubscription already make. A customer who already holds more than one
+// entitling subscription (the pre-existing-bug state) has this pick the furthest-reaching
+// one; the other is left for an operator to clean up by hand.
+func decideCheckoutTarget(sub subscriber, requestedPrice string, proPrices, ultraPrices []string) checkoutTarget {
+	current := bestEntitling(sub, combinedPrices(proPrices, ultraPrices))
+	if current.Status == "" {
+		return checkoutTarget{}
+	}
+	if slices.Contains(current.PriceIDs, requestedPrice) {
+		return checkoutTarget{AlreadyOnPrice: true}
+	}
+	return checkoutTarget{SubscriptionID: current.ID, ItemID: current.ItemID}
+}
+
+// combinedPrices merges both tiers' price lists for the callers that must ask "does this
+// subscription entitle at ALL", regardless of which tier — deciding what to modify on an
+// upgrade, and counting how many subscriptions currently entitle.
+func combinedPrices(proPrices, ultraPrices []string) []string {
+	combined := make([]string, 0, len(proPrices)+len(ultraPrices))
+	combined = append(combined, proPrices...)
+	combined = append(combined, ultraPrices...)
+	return combined
+}
+
+// moreThanOneEntitling reports whether a customer holds more than one active entitling
+// subscription across both configured price lists — the duplicate-subscription bug's own
+// signature, for a customer it already happened to.
+//
+// It counts SUBSCRIPTIONS (elements of sub.Subscriptions), never price ids: one Stripe
+// subscription can legitimately carry an item of each tier (see billedSubscription's own
+// comment on the shape an upgrade that adds a price to the existing subscription leaves
+// behind), and that is one subscription, not two.
+func moreThanOneEntitling(sub subscriber, proPrices, ultraPrices []string) bool {
+	prices := combinedPrices(proPrices, ultraPrices)
+	count := 0
+	for _, s := range sub.Subscriptions {
+		if s.entitles(prices) {
+			count++
+			if count > 1 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // bestEntitling is the subscription that decides the plan: of the ones that entitle, the one

--- a/internal/identity/billing/entitlement.go
+++ b/internal/identity/billing/entitlement.go
@@ -175,12 +175,19 @@ func tierFirst(ids, tier []string) []string {
 // exactly as CheckoutURL always did before this type existed.
 type checkoutTarget struct {
 	// SubscriptionID and ItemID name an existing subscription and its item to change in
-	// place. Set together; both empty (and AlreadyOnPrice false) means open a checkout.
+	// place. Set together; both empty (and AlreadyOnPrice, Ambiguous both false) means open
+	// a checkout.
 	SubscriptionID string
 	ItemID         string
 	// AlreadyOnPrice is true when the customer's current entitling subscription already
 	// carries the requested price. Nothing to do.
 	AlreadyOnPrice bool
+	// Ambiguous is true when the customer's current entitling subscription carries more
+	// than one item — the shape billedSubscription's own comment describes an upgrade
+	// through the provider's portal leaving behind — so which item id the requested price
+	// should replace cannot be recovered from price ids alone. Refusing rather than guessing
+	// item[0] avoids silently changing the wrong one.
+	Ambiguous bool
 }
 
 // decideCheckoutTarget is the fix for freehire's duplicate-subscription bug, kept pure and
@@ -192,6 +199,13 @@ type checkoutTarget struct {
 // bestEntitling/billedSubscription already make. A customer who already holds more than one
 // entitling subscription (the pre-existing-bug state) has this pick the furthest-reaching
 // one; the other is left for an operator to clean up by hand.
+//
+// It deliberately shares bestEntitling's "a subscription whose period end cannot be read
+// entitles nobody" rule rather than picking a different one for checkout purposes: a
+// selection that disagreed would let this method believe a customer has an entitling
+// subscription while the rest of billing (SyncUser, the plan derivation) believes they have
+// none — a worse inconsistency than opening a checkout for an account the whole system
+// already treats as unentitled.
 func decideCheckoutTarget(sub subscriber, requestedPrice string, proPrices, ultraPrices []string) checkoutTarget {
 	current := bestEntitling(sub, combinedPrices(proPrices, ultraPrices))
 	if current.Status == "" {
@@ -199,6 +213,9 @@ func decideCheckoutTarget(sub subscriber, requestedPrice string, proPrices, ultr
 	}
 	if slices.Contains(current.PriceIDs, requestedPrice) {
 		return checkoutTarget{AlreadyOnPrice: true}
+	}
+	if len(current.PriceIDs) > 1 {
+		return checkoutTarget{Ambiguous: true}
 	}
 	return checkoutTarget{SubscriptionID: current.ID, ItemID: current.ItemID}
 }

--- a/internal/identity/billing/entitlement_test.go
+++ b/internal/identity/billing/entitlement_test.go
@@ -331,6 +331,48 @@ func TestDecideCheckoutTarget(t *testing.T) {
 			wantAction:     "update",
 			wantSubID:      "sub_pro",
 		},
+		{
+			// One subscription carrying an item of each tier — the shape billedSubscription's
+			// own comment describes an upgrade through the provider's portal leaving behind.
+			// Which item id belongs to which price is not recoverable from price ids alone
+			// (item order is not a documented guarantee — the whole reason tierFirst exists
+			// rather than trusting raw order), so this must refuse to guess rather than
+			// silently replace the wrong item.
+			name: "a subscription holding an item of each tier is ambiguous",
+			sub: sub(subscription{
+				ID: "sub_both", ItemID: "sub_both_item0", Status: "active",
+				CurrentPeriodEnd: at(t, "2026-10-01T00:00:00Z"),
+				PriceIDs:         []string{proPrice, ultraPrice},
+			}),
+			requestedPrice: "price_pro_annual",
+			wantAction:     "ambiguous",
+		},
+		{
+			// An ambiguous subscription that already carries the requested price is still a
+			// no-op: nothing needs to change, so there is nothing to guess about.
+			name: "a subscription holding an item of each tier already on the requested price",
+			sub: sub(subscription{
+				ID: "sub_both", ItemID: "sub_both_item0", Status: "active",
+				CurrentPeriodEnd: at(t, "2026-10-01T00:00:00Z"),
+				PriceIDs:         []string{proPrice, ultraPrice},
+			}),
+			requestedPrice: ultraPrice,
+			wantAction:     "noop",
+		},
+		{
+			// The inherited edge of bestEntitling's own documented, tested design: a
+			// subscription whose period end cannot be read entitles nobody (see the big
+			// comment above the subscription type, and TestProUntilFrom's identical case).
+			// decideCheckoutTarget deliberately reuses that same rule rather than a selection
+			// of its own — disagreeing with it would let this method believe a customer has
+			// an entitling subscription while the rest of billing (SyncUser, the plan
+			// derivation) believes they have none, which is a worse inconsistency than opening
+			// a checkout for an account the whole system already treats as unentitled.
+			name:           "a subscription whose period end cannot be read is treated as no entitling subscription, like everywhere else in this package",
+			sub:            sub(subscription{ID: "sub_broken", Status: "active", PriceIDs: []string{proPrice}}),
+			requestedPrice: ultraPrice,
+			wantAction:     "checkout",
+		},
 	}
 
 	for _, tc := range cases {
@@ -344,6 +386,10 @@ func TestDecideCheckoutTarget(t *testing.T) {
 			case "noop":
 				if !got.AlreadyOnPrice {
 					t.Fatalf("want AlreadyOnPrice, got %+v", got)
+				}
+			case "ambiguous":
+				if !got.Ambiguous {
+					t.Fatalf("want Ambiguous, got %+v", got)
 				}
 			case "update":
 				if got.AlreadyOnPrice {

--- a/internal/identity/billing/entitlement_test.go
+++ b/internal/identity/billing/entitlement_test.go
@@ -277,6 +277,89 @@ func TestTierFirstOrdersAndNeverDrops(t *testing.T) {
 	}
 }
 
+// TestDecideCheckoutTarget pins CheckoutURL's whole decision — open a new Checkout Session,
+// modify an existing subscription in place, or do nothing — kept pure and DB-free so the fix
+// for freehire's duplicate-subscription bug is testable without a database or a network call.
+func TestDecideCheckoutTarget(t *testing.T) {
+	live := func(id, price, end string) subscription {
+		return subscription{ID: id, ItemID: id + "_item", Status: "active", CurrentPeriodEnd: at(t, end), PriceIDs: []string{price}}
+	}
+
+	cases := []struct {
+		name           string
+		sub            subscriber
+		requestedPrice string
+		wantAction     string // "checkout", "update", or "noop"
+		wantSubID      string
+	}{
+		{
+			name:           "no entitling subscription opens a new checkout",
+			sub:            sub(),
+			requestedPrice: proPrice,
+			wantAction:     "checkout",
+		},
+		{
+			name:           "an active Pro subscription requesting Ultra is updated in place",
+			sub:            sub(live("sub_pro", proPrice, "2026-10-01T00:00:00Z")),
+			requestedPrice: ultraPrice,
+			wantAction:     "update",
+			wantSubID:      "sub_pro",
+		},
+		{
+			name:           "an active Ultra subscription requesting Pro is updated in place",
+			sub:            sub(live("sub_ultra", ultraPrice, "2026-10-01T00:00:00Z")),
+			requestedPrice: proPrice,
+			wantAction:     "update",
+			wantSubID:      "sub_ultra",
+		},
+		{
+			name:           "requesting the price already held is a no-op",
+			sub:            sub(live("sub_pro", proPrice, "2026-10-01T00:00:00Z")),
+			requestedPrice: proPrice,
+			wantAction:     "noop",
+		},
+		{
+			// The pre-existing-bug shape this change does not retroactively fix: two
+			// concurrent entitling subscriptions. The decision picks the best-entitling one
+			// (furthest reach) and leaves the other for an operator to clean up by hand.
+			name: "two concurrent entitling subscriptions: the best-entitling one is updated",
+			sub: sub(
+				live("sub_pro", proPrice, "2027-03-01T00:00:00Z"),
+				live("sub_ultra", ultraPrice, "2026-10-01T00:00:00Z"),
+			),
+			requestedPrice: "price_pro_annual",
+			wantAction:     "update",
+			wantSubID:      "sub_pro",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decideCheckoutTarget(tc.sub, tc.requestedPrice, []string{proPrice}, []string{ultraPrice})
+			switch tc.wantAction {
+			case "checkout":
+				if got != (checkoutTarget{}) {
+					t.Fatalf("want opening a new checkout (zero target), got %+v", got)
+				}
+			case "noop":
+				if !got.AlreadyOnPrice {
+					t.Fatalf("want AlreadyOnPrice, got %+v", got)
+				}
+			case "update":
+				if got.AlreadyOnPrice {
+					t.Fatalf("want an update, got AlreadyOnPrice: %+v", got)
+				}
+				if got.SubscriptionID != tc.wantSubID {
+					t.Fatalf("want subscription %q updated, got %+v", tc.wantSubID, got)
+				}
+				if got.ItemID != tc.wantSubID+"_item" {
+					t.Fatalf("want item %q, got %+v", tc.wantSubID+"_item", got)
+				}
+			}
+		})
+	}
+}
+
 // TestProUntilFromIsIdempotent asserts the property the whole design rests on: the column is
 // DERIVED from provider state, so applying the same state twice yields the same answer and a
 // repeated sync is free.

--- a/internal/identity/billing/overview.go
+++ b/internal/identity/billing/overview.go
@@ -32,6 +32,11 @@ type Overview struct {
 	// the kind of contradiction that generates support mail.
 	EndsAt   *time.Time `json:"ends_at,omitempty"`
 	Invoices []Invoice  `json:"invoices"`
+	// MultipleSubscriptions is true when this customer has more than one active entitling
+	// subscription at once — the duplicate-subscription bug, for a customer it already
+	// happened to. The section still describes the single best-entitling one below; this is
+	// additive information rather than a second code path.
+	MultipleSubscriptions bool `json:"multiple_subscriptions,omitempty"`
 }
 
 // Invoice is one charge as a receipt list shows it.
@@ -107,6 +112,7 @@ func (s *Service) overviewFor(ctx context.Context, customer string) (Overview, e
 	}
 	out.Status = best.Status
 	out.AmountCents, out.Currency, out.Interval = amount, currency, interval
+	out.MultipleSubscriptions = moreThanOneEntitling(sub, s.cfg.Prices, s.cfg.UltraPrices)
 
 	when := best.CurrentPeriodEnd
 	if !best.CancelAt.IsZero() {

--- a/internal/identity/billing/overview_test.go
+++ b/internal/identity/billing/overview_test.go
@@ -192,7 +192,13 @@ func TestSubscriptionOverviewDoesNotFlagASingleSubscription(t *testing.T) {
 	s := serviceWithProvider(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/subscriptions":
-			_, _ = w.Write([]byte(`{"object":"list","data":[{"status":"active","items":{"data":[{"current_period_end":4102444800,"price":{"id":"price_ultra_monthly"}}]}}]}`))
+			// ONE subscription object, two items — Pro's id first, deliberately, matching
+			// TestBilledSubscription's identical fixture: the shape an upgrade that adds a
+			// price to the existing subscription (through the provider's own portal) leaves
+			// behind, as opposed to two separate subscription objects.
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"status":"active","items":{"data":[` +
+				`{"current_period_end":4102444800,"price":{"id":"price_pro_monthly"}},` +
+				`{"current_period_end":4102444800,"price":{"id":"price_ultra_monthly"}}]}}]}`))
 		case strings.HasPrefix(r.URL.Path, "/prices/"):
 			_, _ = fmt.Fprintf(w, `{"id":"price_ultra_monthly","unit_amount":1900,"currency":"usd","recurring":{"interval":"month"}}`)
 		default:

--- a/internal/identity/billing/overview_test.go
+++ b/internal/identity/billing/overview_test.go
@@ -175,4 +175,36 @@ func TestSubscriptionOverviewDescribesTheTierThePlanCameFrom(t *testing.T) {
 	if out.RenewsAt == nil || out.RenewsAt.Unix() != endsIn2030 {
 		t.Fatalf("want the Ultra subscription's renewal date, got %v", out.RenewsAt)
 	}
+	// Same fixture, same two live subscriptions as the case above — this is the reported
+	// duplicate-subscription bug shape (Pro + Ultra both billing at once), and the overview
+	// must say so rather than silently showing only the better one.
+	if !out.MultipleSubscriptions {
+		t.Fatalf("want MultipleSubscriptions, got %+v", out)
+	}
+}
+
+// TestSubscriptionOverviewDoesNotFlagASingleSubscription guards against a false positive: a
+// subscription that legitimately carries an item of each tier (what an upgrade that adds a
+// price to the existing subscription leaves behind, per billedSubscription's own comment)
+// is still exactly ONE subscription and must not be reported as a duplicate.
+func TestSubscriptionOverviewDoesNotFlagASingleSubscription(t *testing.T) {
+	t.Setenv("STRIPE_ULTRA_PRICE_IDS", ultraPrice)
+	s := serviceWithProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/subscriptions":
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"status":"active","items":{"data":[{"current_period_end":4102444800,"price":{"id":"price_ultra_monthly"}}]}}]}`))
+		case strings.HasPrefix(r.URL.Path, "/prices/"):
+			_, _ = fmt.Fprintf(w, `{"id":"price_ultra_monthly","unit_amount":1900,"currency":"usd","recurring":{"interval":"month"}}`)
+		default:
+			_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+		}
+	})
+
+	out, err := s.overviewFor(context.Background(), "cus_9")
+	if err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+	if out.MultipleSubscriptions {
+		t.Fatalf("a single subscription must never be reported as a duplicate: %+v", out)
+	}
 }

--- a/internal/identity/billing/service.go
+++ b/internal/identity/billing/service.go
@@ -333,10 +333,17 @@ func (s *Service) CheckoutURL(ctx context.Context, userID int64, priceID string,
 	}
 
 	// An existing customer is reused so a second purchase cannot create a second customer for
-	// one person — which would leave two subscriptions nobody sums.
+	// one person — which would leave two subscriptions nobody sums. A failure to even read
+	// the binding is refused rather than silently treated as "no customer": a transient DB
+	// error would otherwise make a known customer look unbound and open a checkout that
+	// creates a second Stripe customer and a second subscription — the same fix this whole
+	// method exists for, applied one query earlier.
 	existing, err := s.q.GetStripeCustomerID(ctx, userID)
+	if err != nil {
+		return "", Discount{}, fmt.Errorf("billing: reading the Stripe customer of user %d: %w", userID, err)
+	}
 	var customerID string
-	if err == nil && existing.Valid {
+	if existing.Valid {
 		customerID = existing.String
 	}
 

--- a/internal/identity/billing/service.go
+++ b/internal/identity/billing/service.go
@@ -304,11 +304,15 @@ func NewWithBase(cfg Config, q *db.Queries, baseURL string) *Service {
 // accident. Everything outside this package needs an answer about billing, not the
 // credentials it was derived from — Enabled() is that answer.
 
-// CheckoutURL is where this account buys Pro.
+// CheckoutURL is where this account buys, upgrades or downgrades a subscription.
 //
 // The account's id is taken from the caller's session and never from the request: it decides
 // who gets charged and who becomes Pro, and a value the browser composes is a value the
 // browser can change.
+//
+// A customer who already has an entitling subscription is never sent to a new Checkout
+// Session for a different price — that is the duplicate-subscription bug this method used to
+// have. Instead their existing subscription is changed in place; see decideCheckoutTarget.
 func (s *Service) CheckoutURL(ctx context.Context, userID int64, priceID string, discount Discount) (string, error) {
 	if !s.cfg.CanCheckout() {
 		return "", ErrNoCheckout
@@ -328,6 +332,30 @@ func (s *Service) CheckoutURL(ctx context.Context, userID int64, priceID string,
 	var customerID string
 	if err == nil && existing.Valid {
 		customerID = existing.String
+	}
+
+	if customerID != "" {
+		// A known customer may already have an entitling subscription. Reading it here and
+		// failing the whole call on error — rather than falling back to opening a new
+		// checkout — is the line the fix depends on: falling back would silently recreate the
+		// exact bug (a transient read failure would open a second subscription beside a live
+		// one).
+		current, err := s.client.subscriberState(ctx, customerID)
+		if err != nil {
+			return "", fmt.Errorf("billing: reading the subscriptions of user %d: %w", userID, err)
+		}
+		target := decideCheckoutTarget(current, priceID, s.cfg.Prices, s.cfg.UltraPrices)
+		switch {
+		case target.AlreadyOnPrice:
+			return s.cfg.ReturnURL(), nil
+		case target.SubscriptionID != "":
+			if err := s.client.updateSubscriptionPrice(ctx, target.SubscriptionID, target.ItemID, priceID); err != nil {
+				return "", fmt.Errorf("billing: upgrading user %d to price %q: %w", userID, priceID, err)
+			}
+			return s.cfg.ReturnURL(), nil
+		}
+		// No entitling subscription (a free account, or a former subscriber whose last one
+		// ended): fall through to opening a checkout, exactly as before.
 	}
 
 	// Pre-fill the address we already hold, so a buyer does not retype what we asked them for

--- a/internal/identity/billing/service.go
+++ b/internal/identity/billing/service.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -313,9 +314,14 @@ func NewWithBase(cfg Config, q *db.Queries, baseURL string) *Service {
 // A customer who already has an entitling subscription is never sent to a new Checkout
 // Session for a different price — that is the duplicate-subscription bug this method used to
 // have. Instead their existing subscription is changed in place; see decideCheckoutTarget.
-func (s *Service) CheckoutURL(ctx context.Context, userID int64, priceID string, discount Discount) (string, error) {
+//
+// The returned Discount is what was actually APPLIED, never simply the one the caller
+// offered: an in-place update never applies one (see decideCheckoutTarget's Non-Goal in
+// design.md), and a caller that echoed the input regardless would tell a subscriber a
+// discount was used when their bill never reflected it.
+func (s *Service) CheckoutURL(ctx context.Context, userID int64, priceID string, discount Discount) (string, Discount, error) {
 	if !s.cfg.CanCheckout() {
-		return "", ErrNoCheckout
+		return "", Discount{}, ErrNoCheckout
 	}
 
 	// A price the browser named must be one we actually sell. The parameter arrives from the
@@ -323,7 +329,7 @@ func (s *Service) CheckoutURL(ctx context.Context, userID int64, priceID string,
 	if priceID == "" {
 		priceID = s.cfg.CheckoutPrice()
 	} else if !s.cfg.Sells(priceID) {
-		return "", fmt.Errorf("%w: price %q is not offered", ErrNoCheckout, priceID)
+		return "", Discount{}, fmt.Errorf("%w: price %q is not offered", ErrNoCheckout, priceID)
 	}
 
 	// An existing customer is reused so a second purchase cannot create a second customer for
@@ -342,17 +348,25 @@ func (s *Service) CheckoutURL(ctx context.Context, userID int64, priceID string,
 		// one).
 		current, err := s.client.subscriberState(ctx, customerID)
 		if err != nil {
-			return "", fmt.Errorf("billing: reading the subscriptions of user %d: %w", userID, err)
+			return "", Discount{}, fmt.Errorf("billing: reading the subscriptions of user %d: %w", userID, err)
 		}
 		target := decideCheckoutTarget(current, priceID, s.cfg.Prices, s.cfg.UltraPrices)
 		switch {
 		case target.AlreadyOnPrice:
-			return s.cfg.ReturnURL(), nil
+			return s.cfg.ReturnURL(), Discount{}, nil
+		case target.Ambiguous:
+			return "", Discount{}, fmt.Errorf(
+				"billing: user %d's subscription carries more than one item; refusing to guess which one to change", userID)
 		case target.SubscriptionID != "":
-			if err := s.client.updateSubscriptionPrice(ctx, target.SubscriptionID, target.ItemID, priceID); err != nil {
-				return "", fmt.Errorf("billing: upgrading user %d to price %q: %w", userID, priceID, err)
+			// A fresh key per call: this protects one call's own low-level HTTP retries from
+			// double-billing a proration, not repeated user clicks — a genuine second attempt
+			// gets a fresh key and is itself idempotent in EFFECT (setting an already-current
+			// price again changes nothing).
+			idempotencyKey := uuid.NewString()
+			if err := s.client.updateSubscriptionPrice(ctx, target.SubscriptionID, target.ItemID, priceID, idempotencyKey); err != nil {
+				return "", Discount{}, fmt.Errorf("billing: upgrading user %d to price %q: %w", userID, priceID, err)
 			}
-			return s.cfg.ReturnURL(), nil
+			return s.cfg.ReturnURL(), Discount{}, nil
 		}
 		// No entitling subscription (a free account, or a former subscriber whose last one
 		// ended): fall through to opening a checkout, exactly as before.
@@ -376,12 +390,16 @@ func (s *Service) CheckoutURL(ctx context.Context, userID int64, priceID string,
 	if !discount.none() {
 		couponID, err = s.client.createCoupon(ctx, discount.PercentOff, discount.Label, discount.Key)
 		if err != nil {
-			return "", fmt.Errorf("billing: minting a discount for user %d: %w", userID, err)
+			return "", Discount{}, fmt.Errorf("billing: minting a discount for user %d: %w", userID, err)
 		}
 	}
 
-	return s.client.createCheckoutSession(ctx, userID, email,
+	url, err := s.client.createCheckoutSession(ctx, userID, email,
 		priceID, s.cfg.ReturnURL(), s.cfg.ReturnURL(), customerID, couponID)
+	if err != nil {
+		return "", Discount{}, err
+	}
+	return url, discount, nil
 }
 
 // HasCollectedAtLeast reports whether this customer has had an invoice collecting at least

--- a/internal/identity/billing/service_test.go
+++ b/internal/identity/billing/service_test.go
@@ -31,7 +31,7 @@ func TestDisabledServiceRefusesEverything(t *testing.T) {
 	if err := s.SyncUser(context.Background(), 1); !errors.Is(err, ErrDisabled) {
 		t.Errorf("SyncUser: want ErrDisabled, got %v", err)
 	}
-	if _, err := s.CheckoutURL(context.Background(), 1, "", Discount{}); !errors.Is(err, ErrNoCheckout) {
+	if _, _, err := s.CheckoutURL(context.Background(), 1, "", Discount{}); !errors.Is(err, ErrNoCheckout) {
 		t.Errorf("CheckoutURL: want ErrNoCheckout, got %v", err)
 	}
 	if _, err := s.ManagementURL(context.Background(), 1); !errors.Is(err, ErrNoCheckout) {

--- a/openspec/changes/fix-subscription-upgrade-duplicate/.openspec.yaml
+++ b/openspec/changes/fix-subscription-upgrade-duplicate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/fix-subscription-upgrade-duplicate/design.md
+++ b/openspec/changes/fix-subscription-upgrade-duplicate/design.md
@@ -1,0 +1,133 @@
+## Context
+
+See `proposal.md` — Why. The relevant code today:
+
+- `Service.CheckoutURL` (`internal/identity/billing/service.go`) always calls
+  `client.createCheckoutSession`, which always opens a new Stripe Checkout Session
+  (`mode=subscription`), reusing an existing Stripe *customer* id but never an existing
+  *subscription*.
+- `client.subscriberState` already reads a customer's subscriptions, but the parsed
+  `subscription` struct (`internal/identity/billing/entitlement.go`) carries no subscription
+  id or item id — only status, dates, and price ids — because nothing needed to name a
+  subscription to modify it before now.
+- `entitlement.go`'s `bestEntitling`/`billedSubscription` already resolve, from a customer's
+  raw subscription list, which single subscription "counts" for a given price list. The
+  in-code comment on `billedSubscription` already describes the intended shape — "an upgrade
+  that adds the new price to the existing subscription rather than opening a second one" —
+  which is the behavior this change implements; nothing in the codebase did that yet.
+- `internal/identity/billing/AGENTS.md`'s "What is deliberately absent" section rules out "a
+  cancellation flow of our own." That constraint is untouched: this change never cancels a
+  subscription, it changes what an *existing, still-open* subscription is billed for.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A signed-in customer with an active entitling subscription who requests a different price
+  (a different tier, or a different interval of the same tier) ends the request with exactly
+  one active entitling subscription, changed in place with proration.
+- A customer with no active entitling subscription is unaffected: they still go through
+  `createCheckoutSession`, exactly as today.
+- A customer who is already found to have more than one active entitling subscription (the
+  pre-existing-bug state) is told so on their billing overview, instead of the overview
+  silently picking one and hiding the other.
+
+**Non-Goals:**
+- Cleaning up subscriptions that are *already* duplicated for existing customers. That is an
+  operator action (Stripe dashboard or Customer Portal), out of scope for this change.
+- Applying a promo discount/coupon to an in-place tier change. `Discount` continues to apply
+  only to a brand-new Checkout Session; see Decisions.
+- Any change to the cancellation flow. That continues to be Stripe's Customer Portal, linked
+  via `ManagementURL`.
+
+## Decisions
+
+**Decide purely, act separately.** The choice of what to do — open a new checkout, update an
+existing subscription in place, or do nothing because the customer already has the requested
+price — is a pure function of the customer's current subscriptions and the requested price
+id, with no I/O. It lives in `entitlement.go` beside `bestEntitling`/`billedSubscription`,
+which already make the same kind of decision, and is unit-tested the same way (table-driven,
+no database, no network — see `TestBilledSubscription`/`TestProUntilFrom` for the existing
+pattern). `CheckoutURL` becomes a thin orchestrator: read the customer's subscriptions, call
+the pure function, then either call `createCheckoutSession` or the new
+`client.updateSubscriptionPrice`.
+
+Alternative considered: decide inline inside `CheckoutURL`. Rejected because `CheckoutURL`
+needs `*db.Queries` for `GetStripeCustomerID`/`UserEmail`, which makes it untestable without a
+real database (there is no existing unit test for it beyond the disabled-service case) —
+exactly the gap that let this bug ship unnoticed. Pulling the decision out is what makes it
+testable at all.
+
+**Modify in place via Stripe's subscription-item replacement, not the Customer Portal's
+`subscription_update` flow.** `POST /v1/subscriptions/{id}` with `items[0][id]`,
+`items[0][price]` and `proration_behavior=create_prorations` changes the existing
+subscription's price server-side, synchronously, and returns to the same `/my/plan` page the
+checkout flow already returns to.
+
+Alternative considered: redirect to a Customer Portal session opened with
+`flow_data[type]=subscription_update`. Rejected for now — it would return control to Stripe's
+hosted UI for a click the user already made on our own pricing page (confirming a choice
+they already confirmed), and `createPortalSession` today opens a portal with no `flow_data`
+at all, which would need its own plumbing. The direct API call keeps the existing UX (click
+"Upgrade to Ultra", land back on `/my/plan`) unchanged for the customer.
+
+**Which subscription counts, when a customer might already have more than one:** the pure
+decision function asks across *both* configured price lists (`Config.Prices` +
+`Config.UltraPrices`) for the customer's single best-entitling subscription (reusing
+`bestEntitling`), the same tier-agnostic selection `billedSubscription` already makes. A
+customer already duplicated (the pre-existing bug) has this function pick one — the
+furthest-reaching — and leaves the other untouched; see Non-Goals.
+
+**A subscription's item id is the FIRST item's id.** Every subscription this integration
+creates carries exactly one item (`createCheckoutSession` sends one `line_items[0]`), and
+after this change an upgrade/downgrade replaces that one item's price rather than adding a
+second item — so a subscription this integration manages never grows a second item going
+forward. Reading only `items.data[0].id` is therefore not a simplification that could regress
+silently; it matches the one invariant this integration maintains.
+
+**No discount/coupon on an in-place update.** `CheckoutURL` still accepts a `Discount` and
+still applies it — via `createCoupon` + `discounts[0][coupon]` — only on the
+new-Checkout-Session branch, exactly as today. A discount is a reason to make a *first*
+purchase (the promo/invite-reward system's own framing); extending it to a tier change already
+in progress is a product question this bug fix does not need to answer, and skipping it keeps
+the change's surface small.
+
+**The billing overview reports a boolean, not a list.** `Overview` gains
+`MultipleSubscriptions bool` (`omitempty`), decided by counting *distinct subscription ids*
+(not price ids — one subscription can legitimately carry items of more than one tier per the
+existing `billedSubscription` comment) that entitle across both price lists. The overview
+still resolves and shows the single best-entitling one for its status/amount/date, exactly as
+today; the boolean is additive information, not a second code path.
+
+## Risks / Trade-offs
+
+- **[Risk]** A customer already duplicated by the bug, who now triggers another tier change,
+  gets only their best-entitling subscription updated — the other keeps billing. →
+  **Mitigation:** the overview's new `multiple_subscriptions` flag makes this visible on
+  `/my/plan` (frontend surfaces a message pointing at "Manage subscription", which already
+  links to the Customer Portal where the extra subscription can be cancelled by hand). Full
+  automated remediation of existing duplicates is explicitly out of scope (see Non-Goals).
+- **[Risk]** `client.subscriberState` now runs on the checkout path for every returning
+  customer (previously it only ran on `/billing/subscription` and the webhook/reconciler
+  paths), adding one provider round trip and one more way `CheckoutURL` can fail for an
+  existing customer. → **Mitigation:** failing this read fails the whole call (an error, not a
+  fallback to creating a new checkout) — deliberately, because falling back would silently
+  recreate the exact bug being fixed. A first-time buyer (no stored customer id) is unaffected
+  and never takes this path.
+- **[Trade-off]** Proration on an in-place upgrade charges/credits the difference
+  immediately (Stripe's `create_prorations` default), which is a different billing experience
+  from "a whole new subscription starting today, old one still running until it lapses." This
+  is the correct behavior for the bug being fixed (only one subscription should ever exist)
+  and matches how Stripe's own Customer Portal upgrade flow already behaves.
+
+## Migration Plan
+
+- No schema change and no data migration. `internal/identity/billing/AGENTS.md`'s "no local
+  subscription state machine" rule holds: everything this change reads and writes lives at
+  Stripe.
+- Deploy as an ordinary backend + frontend change; no ordering constraint against other
+  in-flight work.
+- Rollback is a plain revert: the previous behavior (always open a new Checkout Session) is
+  restored, and no stored data needs to be undone.
+- Existing customers already duplicated by the bug are not touched by this change and need a
+  manual fix (cancel the extra subscription via the Customer Portal or Stripe dashboard) —
+  called out to the user in this conversation for their own account already.

--- a/openspec/changes/fix-subscription-upgrade-duplicate/proposal.md
+++ b/openspec/changes/fix-subscription-upgrade-duplicate/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Upgrading from Pro to Ultra (and any other tier-to-tier change) opens a brand-new Stripe Checkout Session instead of changing the customer's existing subscription. The old subscription is never cancelled, so the customer ends up with two independent, concurrently-billing Stripe subscriptions (e.g. Pro $5/mo + Ultra $19/mo), and the app's own billing overview shows only the better-entitling one, hiding the still-active duplicate charge from the customer. A real customer was double-billed this way (freehire#none yet — found via support report on 2026-09-09).
+
+## What Changes
+
+- `POST /api/v1/billing/checkout` (or a new endpoint) modifies an existing entitling subscription in place — via Stripe's subscription-item replacement with proration — when the requesting customer already has one, instead of opening a second Checkout Session. Checkout Session creation is used only for a customer's first subscription.
+- The billing overview (`GET /billing/subscription`) reports when a customer has more than one entitling subscription active, instead of silently picking the best one, so a customer already in this state (or reached by a future bug) can see and act on it rather than being charged for both.
+- Impacted files: `internal/api/handler/billing.go`, `internal/identity/billing/service.go`, `internal/identity/billing/client.go`, `internal/identity/billing/entitlement.go`, `internal/identity/billing/overview.go`, `web/src/lib/components/PlanView.svelte`, `web/src/routes/pricing/+page.svelte`, `web/src/lib/api.ts`.
+
+## Capabilities
+
+### New Capabilities
+- `subscription-billing`: purchasing, upgrading/downgrading, and viewing the state of a paid subscription (Pro/Ultra) against the payment provider (Stripe) — the checkout flow, the upgrade-in-place behavior, and what the billing overview reports.
+
+### Modified Capabilities
+(none — `subscription-billing` did not exist as a spec before this change)
+
+## Impact
+
+- **Backend**: `internal/identity/billing` (service, client, entitlement, overview) and `internal/api/handler/billing.go`. No schema/migration change expected — Stripe is the system of record for subscription state, per `internal/identity/billing/AGENTS.md`'s "no local subscription state machine" rule.
+- **Frontend**: `web/src/lib/components/PlanView.svelte`, `web/src/routes/pricing/+page.svelte`, `web/src/lib/api.ts` — the upgrade button's request/redirect flow, and a warning surfaced if the overview reports more than one entitling subscription.
+- **External**: Stripe API — introduces the first call in this codebase to `POST /v1/subscriptions/{id}` (update with proration); no new webhook events needed, since `customer.subscription.updated` is already handled.
+- **Manual remediation**: this change does not touch already-duplicated Stripe subscriptions for existing customers — an operator must cancel the extra subscription by hand (e.g. via the Stripe dashboard or Customer Portal) for anyone already affected.

--- a/openspec/changes/fix-subscription-upgrade-duplicate/specs/subscription-billing/spec.md
+++ b/openspec/changes/fix-subscription-upgrade-duplicate/specs/subscription-billing/spec.md
@@ -5,7 +5,7 @@ Governs how a signed-in user buys, upgrades, downgrades, and views the state of 
 ## ADDED Requirements
 
 ### Requirement: Upgrading or downgrading modifies the existing subscription
-When a customer who already has an active, entitling subscription requests a different tier, the system SHALL change that existing subscription's price in place (with proration) rather than starting a new, separate subscription. The customer SHALL end this action with exactly one active entitling subscription.
+When a customer who already has exactly one active, entitling subscription requests a different tier, the system SHALL change that existing subscription's price in place (with proration) rather than starting a new, separate subscription. The customer SHALL end this action with exactly one active entitling subscription.
 
 #### Scenario: Customer with an active Pro subscription upgrades to Ultra
 - **WHEN** a customer with an active Pro subscription requests the Ultra tier
@@ -16,6 +16,15 @@ When a customer who already has an active, entitling subscription requests a dif
 #### Scenario: Customer with an active Ultra subscription downgrades to Pro
 - **WHEN** a customer with an active Ultra subscription requests the Pro tier
 - **THEN** the system updates the existing subscription's price to the Pro price with proration
+- **AND** no new subscription is created for that customer
+
+### Requirement: A customer already holding more than one entitling subscription is not retroactively fixed
+When a customer is found to already have more than one active entitling subscription (a state this system no longer creates going forward, but does not undo for an account it already happened to), a further tier change SHALL modify only the best-entitling one — never open an additional subscription, and never guess at reconciling the others.
+
+#### Scenario: Customer already has two concurrent entitling subscriptions and requests a further tier change
+- **WHEN** a customer who already holds two active entitling subscriptions (at different tiers) requests a third tier
+- **THEN** the system changes the best-entitling subscription's price in place
+- **AND** the other, already-duplicated subscription is left untouched
 - **AND** no new subscription is created for that customer
 
 ### Requirement: A customer's first subscription is created via checkout

--- a/openspec/changes/fix-subscription-upgrade-duplicate/specs/subscription-billing/spec.md
+++ b/openspec/changes/fix-subscription-upgrade-duplicate/specs/subscription-billing/spec.md
@@ -1,0 +1,35 @@
+## Purpose
+
+Governs how a signed-in user buys, upgrades, downgrades, and views the state of a paid subscription (Pro/Ultra) against the payment provider, so a tier change never results in more than one subscription billing the same customer.
+
+## ADDED Requirements
+
+### Requirement: Upgrading or downgrading modifies the existing subscription
+When a customer who already has an active, entitling subscription requests a different tier, the system SHALL change that existing subscription's price in place (with proration) rather than starting a new, separate subscription. The customer SHALL end this action with exactly one active entitling subscription.
+
+#### Scenario: Customer with an active Pro subscription upgrades to Ultra
+- **WHEN** a customer with an active Pro subscription requests the Ultra tier
+- **THEN** the system updates the existing subscription's price to the Ultra price with proration
+- **AND** no new subscription is created for that customer
+- **AND** the customer has exactly one active entitling subscription afterward
+
+#### Scenario: Customer with an active Ultra subscription downgrades to Pro
+- **WHEN** a customer with an active Ultra subscription requests the Pro tier
+- **THEN** the system updates the existing subscription's price to the Pro price with proration
+- **AND** no new subscription is created for that customer
+
+### Requirement: A customer's first subscription is created via checkout
+When a customer has no active entitling subscription, requesting a tier SHALL create a new subscription through the payment provider's hosted checkout, as before.
+
+#### Scenario: Customer with no active subscription buys Pro
+- **WHEN** a customer with no active entitling subscription requests the Pro tier
+- **THEN** the system creates a new subscription via a hosted checkout session
+- **AND** the resulting subscription is billed at the Pro price
+
+### Requirement: The billing overview reports more than one entitling subscription
+If a customer is found to have more than one active entitling subscription at the payment provider, the billing overview SHALL report this state explicitly instead of silently presenting only the best-entitling one.
+
+#### Scenario: Customer already has two concurrent subscriptions
+- **WHEN** a customer's billing overview is requested and the payment provider reports more than one active entitling subscription for that customer
+- **THEN** the overview response indicates that more than one entitling subscription is active
+- **AND** the overview still reports the best-entitling tier for access-control purposes

--- a/openspec/changes/fix-subscription-upgrade-duplicate/tasks.md
+++ b/openspec/changes/fix-subscription-upgrade-duplicate/tasks.md
@@ -75,4 +75,55 @@
       the SAME subscription now carries the Ultra price (one subscription, one item, price
       swapped), not a second subscription. **Not run in this session** — no Stripe test-mode
       credentials or database available in the sandboxed environment; needs a human (or a
-      staging deploy) with `STRIPE_SECRET_KEY` pointed at a Stripe test-mode account.
+      staging deploy) with `STRIPE_SECRET_KEY` pointed at a Stripe test-mode account. Partially
+      substituted by 7.5 below (a real-Postgres, stubbed-Stripe integration test exercising
+      the same path), which is a lower bar than a real Stripe test-mode account.
+
+## 7. Code review follow-ups
+
+A first review (before this section existed) found the core architecture sound but flagged
+two ways the new logic could still silently reopen a duplicate/mis-billed subscription given
+unusual subscription data, plus a response-contract gap. Addressed here rather than filed as
+follow-up issues, since the whole point of this change is closing exactly those paths.
+
+- [x] 7.1 **Important:** a subscription carrying more than one item (a customer who upgraded
+      through Stripe's own Customer Portal, which can add a new item to an existing
+      subscription rather than replace one) must not have its price replaced by silently
+      guessing item[0] — the requested price might belong to a different item entirely. Added
+      `checkoutTarget.Ambiguous`; `decideCheckoutTarget` returns it when the selected
+      subscription's `PriceIDs` has more than one entry, and `CheckoutURL` turns that into an
+      error rather than a checkout or an update. Table-driven cases added to
+      `TestDecideCheckoutTarget`; integration coverage in `TestCheckoutURLRefusesToGuessOnAnAmbiguousSubscription`.
+- [x] 7.2 **Important (documented, not changed):** `decideCheckoutTarget` reuses
+      `bestEntitling`'s existing, deliberate "a subscription whose period end cannot be read
+      entitles nobody" rule (see the big comment on the `subscription` type and
+      `TestProUntilFrom`). A selection of its own for checkout purposes would let `CheckoutURL`
+      believe a customer is entitled while the rest of billing (`SyncUser`, the plan
+      derivation) believes they are not — a worse inconsistency than opening a checkout for an
+      account the whole system already treats as unentitled. Pinned with a dedicated test case
+      and a comment explaining why, rather than left as an unstated assumption.
+- [x] 7.3 **Important:** `CheckoutURL` computed a discount and the `/billing/checkout` handler
+      always reported it as applied, even when the update-in-place branch took it and
+      (correctly, per design.md) dropped it. `CheckoutURL` now returns the Discount that was
+      actually applied — `Discount{}` for every in-place-update/no-op branch, the input
+      `discount` only when a Checkout Session coupon was actually minted — and the handler
+      reports that instead of the input. Covered by
+      `TestCheckoutURLUpdatesAnExistingSubscriptionInPlace` (discount dropped, no coupon call)
+      and `TestCheckoutURLOpensACheckoutSessionForAKnownCustomerWithNoSubscription` (discount
+      applied, coupon minted).
+- [x] 7.4 **Minor:** `updateSubscriptionPrice` now carries a fresh idempotency key per call
+      (`uuid.NewString()`, already a module dependency) — it creates a proration invoice item,
+      and without a key a low-level HTTP transport retry of the same request could bill the
+      same change twice. Test extended in `client_test.go`.
+- [x] 7.5 **Minor:** added `checkout_integration_test.go` (real Postgres via testcontainers,
+      stubbed Stripe) exercising `CheckoutURL` end to end — the one piece of the fix
+      (`GetStripeCustomerID` → `decideCheckoutTarget` → `updateSubscriptionPrice`/
+      `createCheckoutSession` wiring in `service.go`) the pure unit tests cannot reach, per
+      design.md's own stated reason `CheckoutURL` has no dedicated unit test. Three tests: an
+      existing entitling subscription is updated in place and no coupon/checkout call is made;
+      a known customer with no entitling subscription still reaches an ordinary checkout with
+      its discount applied; an ambiguous (multi-item) subscription is refused rather than
+      guessed at.
+- [x] 7.6 **Minor:** fixed `PlanView.messages.ts`'s `duplicateWarning` copy — it said
+      "...below" but the "Manage or cancel" link it refers to renders above the subscription
+      section, not below it. Reworded to be layout-independent (en + ru).

--- a/openspec/changes/fix-subscription-upgrade-duplicate/tasks.md
+++ b/openspec/changes/fix-subscription-upgrade-duplicate/tasks.md
@@ -1,0 +1,78 @@
+## 1. Provider client: name and modify an existing subscription
+
+- [x] 1.1 Add `ID` (subscription id) and the first item's `ID` to
+      `stripeSubscriptionList` in `internal/identity/billing/client.go`, and carry both onto
+      the parsed `subscription` (new fields `ID`, `ItemID` in `entitlement.go`).
+- [x] 1.2 Add `client.updateSubscriptionPrice(ctx, subscriptionID, itemID, priceID string) error`
+      calling `POST /v1/subscriptions/{id}` with `items[0][id]`, `items[0][price]`, and
+      `proration_behavior=create_prorations`.
+- [x] 1.3 Unit test `updateSubscriptionPrice` against the `testClient` stub (assert path and
+      form fields), following the `TestClientCheckoutSession` pattern.
+- [x] 1.4 Unit test that `subscriberState` now parses the subscription id and the first item's
+      id from a fixture response (extend `TestClientSubscriberState`).
+
+## 2. Pure decision: what CheckoutURL should do
+
+- [x] 2.1 In `entitlement.go`, add a pure function deciding, from a customer's current
+      `subscriber` and a requested price id, whether to: do nothing (already on that price),
+      update an existing subscription in place (returning its subscription id + item id), or
+      open a new checkout (no entitling subscription at all) — searching across both
+      `proPrices` and `ultraPrices` combined, reusing `bestEntitling`.
+- [x] 2.2 Table-driven unit tests for it in `entitlement_test.go`, covering: no subscription
+      (→ new checkout), an active Pro subscription requesting Ultra (→ update in place), an
+      active Ultra subscription requesting Pro (→ update in place), a request for the price
+      already held (→ no-op), and a customer already holding two entitling subscriptions
+      (→ update in place picks the best-entitling one, per design.md's stated Non-Goal).
+
+## 3. Wire it into CheckoutURL
+
+- [x] 3.1 In `Service.CheckoutURL` (`service.go`), when an existing Stripe customer id is
+      found, read `client.subscriberState`, apply the task 2.1 decision, and branch: no-op
+      returns `s.cfg.ReturnURL()`; update-in-place calls `updateSubscriptionPrice` and returns
+      `s.cfg.ReturnURL()`; no entitling subscription falls through to the existing
+      `createCheckoutSession` call unchanged.
+- [x] 3.2 A failure reading `subscriberState` on this path returns an error (never falls back
+      to opening a new checkout) — this is the one line the bug fix depends on, so make it
+      impossible to miss in review: comment why, next to the `if err != nil`.
+- [x] 3.3 Update `CheckoutURL`'s doc comment to describe the new upgrade/downgrade-in-place
+      behavior, not just "buys Pro".
+
+## 4. Billing overview: surface an existing duplicate
+
+- [x] 4.1 Add `MultipleSubscriptions bool` (`json:"multiple_subscriptions,omitempty"`) to
+      `Overview` in `overview.go`.
+- [x] 4.2 In `overviewFor`, compute it from the count of entitling SUBSCRIPTIONS across both
+      price lists (`moreThanOneEntitling`; counting subscriptions rather than price ids is
+      what keeps a legitimate one-subscription-two-items case from a false positive) — more
+      than one sets the flag — without changing which subscription `best`/the rest of the
+      response describes.
+- [x] 4.3 Unit tests in `overview_test.go` extending the `serviceWithProvider`/`subscribedTo`
+      pattern: one subscription → flag false/absent; two concurrent entitling subscriptions
+      (the reported bug shape: Pro + Ultra both active) → flag true, while `amount_cents`/
+      `renews_at` still describe the best-entitling one exactly as before.
+
+## 5. Frontend
+
+- [x] 5.1 Add `multiple_subscriptions?: boolean` to the `BillingOverview` type
+      (`web/src/lib/types.ts` or wherever it is declared).
+- [x] 5.2 In `PlanView.svelte`, when `billing.multiple_subscriptions` is true, show a warning
+      in the subscription section pointing at "Manage subscription" (the existing
+      `manageUrl` link) to resolve the duplicate — add the copy to `PlanView.messages`
+      alongside the existing strings.
+- [x] 5.3 Confirmed (read the code, no change needed): `pricing/+page.svelte`'s
+      `buy()`/`buyUltra()` and `api.ts`'s `billingCheckout` need no changes — both already just
+      follow whatever URL `/billing/checkout` returns, which is exactly what makes the backend
+      change alone sufficient — `window.location.href = url` lands on `/my/plan` either way.
+      `svelte-check` (0 errors) and `eslint` (clean) confirmed on the changed frontend files.
+
+## 6. Verify
+
+- [x] 6.1 `gofmt -l .` clean, `go vet ./...`, `go test ./...` — all green (see session log:
+      full `go test ./...` run, every package `ok`).
+- [x] 6.2 `go vet -tags=integration ./...` — clean.
+- [ ] 6.3 Manually confirm in a Stripe test-mode account: subscribe to Pro, then click
+      "Upgrade to Ultra" on `/pricing` while signed in — assert via the Stripe dashboard that
+      the SAME subscription now carries the Ultra price (one subscription, one item, price
+      swapped), not a second subscription. **Not run in this session** — no Stripe test-mode
+      credentials or database available in the sandboxed environment; needs a human (or a
+      staging deploy) with `STRIPE_SECRET_KEY` pointed at a Stripe test-mode account.

--- a/web/src/lib/components/PlanView.messages.ts
+++ b/web/src/lib/components/PlanView.messages.ts
@@ -49,7 +49,7 @@ export const messages = defineMessages(
       // customer at once — a state this page never creates going forward, but can still
       // describe for a customer it already happened to.
       duplicateWarning:
-        'You have more than one active subscription, and are being charged for each of them. Open "Manage or cancel" below to cancel the extra one.',
+        'You have more than one active subscription, and are being charged for each of them. Use "Manage or cancel" to cancel the extra one.',
     },
     today: {
       heading: 'Today',
@@ -111,7 +111,7 @@ export const messages = defineMessages(
         nextChargePrefix: 'Следующее списание',
         receipt: 'Чек',
         duplicateWarning:
-          'У вас активно больше одной подписки, и оплата идёт по каждой из них. Откройте «Изменить или отменить» ниже, чтобы отменить лишнюю.',
+          'У вас активно больше одной подписки, и оплата идёт по каждой из них. Используйте «Изменить или отменить», чтобы отменить лишнюю.',
       },
       today: {
         heading: 'Сегодня',

--- a/web/src/lib/components/PlanView.messages.ts
+++ b/web/src/lib/components/PlanView.messages.ts
@@ -45,6 +45,11 @@ export const messages = defineMessages(
       cancelledPrefix: 'Cancelled — access runs until',
       nextChargePrefix: 'Next charge',
       receipt: 'Receipt',
+      // Shown only when the provider reports more than one active subscription for this
+      // customer at once — a state this page never creates going forward, but can still
+      // describe for a customer it already happened to.
+      duplicateWarning:
+        'You have more than one active subscription, and are being charged for each of them. Open "Manage or cancel" below to cancel the extra one.',
     },
     today: {
       heading: 'Today',
@@ -105,6 +110,8 @@ export const messages = defineMessages(
         cancelledPrefix: 'Отменена — доступ действует до',
         nextChargePrefix: 'Следующее списание',
         receipt: 'Чек',
+        duplicateWarning:
+          'У вас активно больше одной подписки, и оплата идёт по каждой из них. Откройте «Изменить или отменить» ниже, чтобы отменить лишнюю.',
       },
       today: {
         heading: 'Сегодня',

--- a/web/src/lib/components/PlanView.svelte
+++ b/web/src/lib/components/PlanView.svelte
@@ -178,6 +178,10 @@
                 {tokenLabel(s.subscription.status, billing.status)}
               </span>
             </div>
+            {#if billing.multiple_subscriptions}
+              <p class="text-xs text-destructive">{s.subscription.duplicateWarning}</p>
+            {/if}
+
             <!-- One date or the other, never both: a renewal date beside a cancellation is
                  the contradiction that generates support mail. -->
             {#if billing.ends_at}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -177,6 +177,10 @@ export interface BillingOverview {
   renews_at?: string;
   ends_at?: string;
   invoices: BillingInvoice[];
+  /** True when the provider reports more than one active entitling subscription for this
+   *  customer at once — the duplicate-subscription bug, for a customer it already happened
+   *  to. Absent (never `false`) for the ordinary case. */
+  multiple_subscriptions?: boolean;
 }
 
 export interface PlanState {


### PR DESCRIPTION
## Summary

- `CheckoutURL` always opened a new Stripe Checkout Session, even for a customer who already had an active entitling subscription — so upgrading (or downgrading) tiers left two Stripe subscriptions billing the same customer in parallel instead of replacing one with the other. A real customer hit this in production (Pro $5/mo + Ultra $19/mo both active at once).
- `CheckoutURL` now reads the customer's current subscriptions and, when one already entitles them, changes it in place via Stripe's subscription item price replacement with proration — never a second Checkout Session. The decision (`decideCheckoutTarget`) is a pure, DB-free function so it's unit-testable without a database or network call; `CheckoutURL` itself is additionally covered by a real-Postgres/stubbed-Stripe integration test.
- Refuses to guess which item to change when a subscription already carries more than one (a shape Stripe's own Customer Portal can produce) — surfaced as an error rather than silently mutating the wrong item.
- The billing overview (`/billing/subscription`) now reports `multiple_subscriptions: true` when a customer already has more than one active entitling subscription, so an existing duplicate is visible on `/my/plan` instead of silently hidden behind the best-entitling one — with a warning banner pointing at "Manage or cancel".
- `CheckoutURL`'s response now reports the discount that was actually applied (never applied on an in-place update), rather than always echoing back what was offered.

Full rationale: `openspec/changes/fix-subscription-upgrade-duplicate/{proposal,design}.md`.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...`
- [x] `go test ./...` (unit)
- [x] `go test -tags=integration ./internal/identity/billing/... ./internal/api/handler/...` (real Postgres via testcontainers)
- [x] `svelte-check` (0 errors) and `eslint` clean on the changed frontend files
- [ ] Manual Stripe test-mode verification (subscribe to Pro, click "Upgrade to Ultra", confirm via the Stripe dashboard it's the same subscription) — **not run**: no Stripe test-mode credentials available in the environment this PR was prepared in. Recommend running this once before/after merge.
- Existing duplicated subscriptions (like the one that surfaced this bug) are **not** cleaned up automatically — needs manual cancellation via the Stripe Customer Portal or dashboard for anyone already affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgrading or downgrading an existing subscription now updates it in place with proration instead of creating a duplicate subscription.
  * New subscriptions continue through hosted checkout.
  * Billing overviews identify customers with multiple active subscriptions.
  * The subscription panel displays a warning when duplicate subscriptions are detected.

* **Bug Fixes**
  * Discount responses report only discounts actually applied.
  * Ambiguous subscription configurations are rejected instead of creating another subscription.
  * Subscription lookup failures now stop checkout rather than opening an additional subscription.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->