### PR TITLE
Let a moderator preview a pending mentor profile

### DIFF
--- a/internal/api/handler/mentorship.go
+++ b/internal/api/handler/mentorship.go
@@ -62,6 +62,7 @@ func (h *mentorshipHandlers) register(api fiber.Router, mw middleware) {
 
 	// Moderation, behind the same gate the referral queue uses.
 	api.Get("/mentorship/profiles", mw.key, mw.moderator, h.ListPendingMentorProfiles)
+	api.Get("/mentorship/profiles/:id/photo", mw.key, mw.moderator, h.GetPendingMentorPhoto)
 	api.Post("/mentorship/profiles/:id/decide", mw.key, mw.moderator, h.DecideMentorProfile)
 }
 
@@ -113,6 +114,11 @@ type mentorResponse struct {
 	Status     string `json:"status,omitempty"`
 	Paused     bool   `json:"paused,omitempty"`
 	MeetingURL string `json:"meeting_url,omitempty"`
+	// CreatedAt is when the profile was submitted — moderator and owner views only. A
+	// visitor deciding whether to book has no use for it, and it says nothing the public
+	// card needs to say. A pointer because `omitempty` does not drop a zero-value
+	// time.Time (it is a struct, not one of the types the encoder treats as "empty").
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// The rest of the session parameters, for the OWNER alone. Pointers rather than plain
 	// ints because a zero buffer is a real setting, and `omitempty` cannot tell "no buffer"
@@ -171,6 +177,7 @@ func toModeratorMentorResponse(p mentorship.Profile) mentorResponse {
 	out := toMentorResponse(p)
 	out.Status = p.Status
 	out.Paused = p.Paused
+	out.CreatedAt = &p.CreatedAt
 	return out
 }
 
@@ -262,6 +269,29 @@ func mentorPhoto(ctx context.Context, profile mentorship.Profile, photos *headsh
 // opted in via show_photo. An unpublished profile answers 404 exactly as GetMentor does.
 func (h *mentorshipHandlers) GetMentorPhoto(c *fiber.Ctx) error {
 	profile, err := h.mentorship.PublicProfile(c.Context(), c.Params("slug"))
+	if err != nil {
+		return fiber.NewError(fiber.StatusNotFound)
+	}
+	data, err := mentorPhoto(c.Context(), profile, h.photos)
+	if err != nil {
+		return fiber.NewError(fiber.StatusNotFound)
+	}
+	c.Set(fiber.HeaderContentType, "image/jpeg")
+	return c.Send(data)
+}
+
+// GetPendingMentorPhoto lets a moderator preview a still-pending mentor's opted-in
+// photo — the same bytes GetMentorPhoto would serve once approved, but resolved by the
+// row id a moderator already reads off the queue rather than by slug, and unconditional
+// on status: ProfileForModeration carries no publication predicate, because the
+// mw.moderator gate in front of this route is the access control, not a second copy of
+// the public one.
+func (h *mentorshipHandlers) GetPendingMentorPhoto(c *fiber.Ctx) error {
+	id, err := c.ParamsInt("id")
+	if err != nil {
+		return fiber.NewError(fiber.StatusNotFound)
+	}
+	profile, err := h.mentorship.ProfileForModeration(c.Context(), int64(id))
 	if err != nil {
 		return fiber.NewError(fiber.StatusNotFound)
 	}

--- a/internal/api/handler/mentorship_moderation_photo_integration_test.go
+++ b/internal/api/handler/mentorship_moderation_photo_integration_test.go
@@ -1,0 +1,145 @@
+//go:build integration
+
+// Integration tests for the moderator-only pending-profile photo route against a real
+// Postgres: it serves a pending, opted-in mentor's photo (which the public, slug-keyed
+// route refuses since the profile is not yet approved), refuses a mentor who has not
+// opted in, refuses an unknown id, and refuses a non-moderator caller.
+// Run with: go test -tags=integration ./internal/api/handler/
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/candidate/headshot"
+	"github.com/strelov1/freehire/internal/engage/mentorship"
+	"github.com/strelov1/freehire/internal/identity/auth"
+	"github.com/strelov1/freehire/internal/platform/db"
+)
+
+func TestModeratorCanPreviewAPendingMentorsPhoto(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	var modID, optedInUserID, optedOutUserID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email, role) VALUES ('mod-photo@example.test', 'moderator') RETURNING id`,
+	).Scan(&modID); err != nil {
+		t.Fatalf("seed moderator: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email) VALUES ('mentor-photo-in@example.test') RETURNING id`,
+	).Scan(&optedInUserID); err != nil {
+		t.Fatalf("seed opted-in mentor: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email) VALUES ('mentor-photo-out@example.test') RETURNING id`,
+	).Scan(&optedOutUserID); err != nil {
+		t.Fatalf("seed opted-out mentor: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO companies (slug, name) VALUES ('photoco', 'photoco') ON CONFLICT DO NOTHING`); err != nil {
+		t.Fatalf("seed company: %v", err)
+	}
+
+	queries := db.New(pool)
+	svc := mentorship.New(mentorship.NewQueriesRepository(queries, pool), mentorship.Config{})
+
+	optedIn, err := svc.SubmitProfile(ctx, mentorship.ProfileInput{
+		UserID: optedInUserID, CompanySlug: "photoco", Slug: "photo-in-mentor",
+		DisplayName: "Photo In", Headline: "Staff Engineer",
+		Topics: []string{"career"}, Languages: []string{"en"}, Timezone: "Europe/Berlin",
+		Session:    mentorship.SessionParams{Duration: time.Hour, MinimumNotice: 2 * time.Hour, Horizon: 30 * 24 * time.Hour},
+		MeetingURL: "https://meet.example.test/photo-in",
+		ShowPhoto:  true,
+	})
+	if err != nil {
+		t.Fatalf("submit opted-in profile: %v", err)
+	}
+	optedOut, err := svc.SubmitProfile(ctx, mentorship.ProfileInput{
+		UserID: optedOutUserID, CompanySlug: "photoco", Slug: "photo-out-mentor",
+		DisplayName: "Photo Out", Headline: "Staff Engineer",
+		Topics: []string{"career"}, Languages: []string{"en"}, Timezone: "Europe/Berlin",
+		Session:    mentorship.SessionParams{Duration: time.Hour, MinimumNotice: 2 * time.Hour, Horizon: 30 * 24 * time.Hour},
+		MeetingURL: "https://meet.example.test/photo-out",
+		ShowPhoto:  false,
+	})
+	if err != nil {
+		t.Fatalf("submit opted-out profile: %v", err)
+	}
+
+	blobs := newFakePhotoBlobs()
+	blobs.objs["headshots/photo-in"] = []byte("jpeg-bytes")
+	photos := headshot.New(blobs, &fakePhotoRepo{key: "headshots/photo-in", set: true})
+
+	h := newMentorshipHandlers(svc, photos)
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	modCookie, _ := iss.Issue(modID, testTokenVersion)
+	strangerCookie, _ := iss.Issue(optedInUserID, testTokenVersion)
+	requireMod := auth.RequireRole(queries, "moderator")
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	keyAuth := auth.RequireAuthOrKey(iss, testVersions, apiKeys{queries})
+	app.Get("/api/v1/mentorship/profiles/:id/photo", keyAuth, requireMod, h.GetPendingMentorPhoto)
+
+	authedRequest := func(path, cookie string) *http.Request {
+		r := httptest.NewRequestWithContext(ctx, fiber.MethodGet, path, nil)
+		r.AddCookie(&http.Cookie{Name: auth.CookieName, Value: cookie})
+		return r
+	}
+
+	t.Run("moderator sees the opted-in mentor's photo", func(t *testing.T) {
+		resp, err := app.Test(authedRequest(mentorPhotoPath(optedIn.ID), modCookie))
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			t.Errorf("status = %d, want 200", resp.StatusCode)
+		}
+	})
+
+	t.Run("a mentor who has not opted in has no photo to preview", func(t *testing.T) {
+		resp, err := app.Test(authedRequest(mentorPhotoPath(optedOut.ID), modCookie))
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusNotFound {
+			t.Errorf("status = %d, want 404", resp.StatusCode)
+		}
+	})
+
+	t.Run("an unknown id is not found", func(t *testing.T) {
+		resp, err := app.Test(authedRequest(mentorPhotoPath(999999999), modCookie))
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusNotFound {
+			t.Errorf("status = %d, want 404", resp.StatusCode)
+		}
+	})
+
+	t.Run("a non-moderator is forbidden", func(t *testing.T) {
+		resp, err := app.Test(authedRequest(mentorPhotoPath(optedIn.ID), strangerCookie))
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusForbidden {
+			t.Errorf("status = %d, want 403", resp.StatusCode)
+		}
+	})
+}
+
+func mentorPhotoPath(id int64) string {
+	return "/api/v1/mentorship/profiles/" + strconv.FormatInt(id, 10) + "/photo"
+}

--- a/internal/api/handler/mentorship_response_test.go
+++ b/internal/api/handler/mentorship_response_test.go
@@ -1,0 +1,26 @@
+package handler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/strelov1/freehire/internal/engage/mentorship"
+)
+
+// A moderator (and the owner) can see when a profile was submitted; the public response
+// never carries it — nothing outside the cabinet/queue needs it, and it is not part of
+// what makes a mentor look trustworthy on the public card.
+func TestCreatedAtIsModeratorAndOwnerOnly(t *testing.T) {
+	submitted := time.Date(2026, time.September, 1, 12, 0, 0, 0, time.UTC)
+	p := mentorship.Profile{CreatedAt: submitted}
+
+	if got := toMentorResponse(p).CreatedAt; got != nil {
+		t.Errorf("public response carries created_at = %v, want nil", got)
+	}
+	if got := toModeratorMentorResponse(p).CreatedAt; got == nil || !got.Equal(submitted) {
+		t.Errorf("moderator response created_at = %v, want %v", got, submitted)
+	}
+	if got := toOwnMentorResponse(p).CreatedAt; got == nil || !got.Equal(submitted) {
+		t.Errorf("owner response created_at = %v, want %v", got, submitted)
+	}
+}

--- a/internal/engage/mentorship/profile.go
+++ b/internal/engage/mentorship/profile.go
@@ -232,6 +232,20 @@ func (s *Service) PendingQueue(ctx context.Context) ([]PendingProfile, error) {
 	return s.repo.ListPendingProfiles(ctx)
 }
 
+// ProfileForModeration reads a profile by its row id, whatever its status. It carries no
+// access check of its own — every caller sits behind the moderator gate already, the
+// same division of labour Decide relies on for the same id.
+func (s *Service) ProfileForModeration(ctx context.Context, id int64) (Profile, error) {
+	profile, found, err := s.repo.ProfileByID(ctx, id)
+	if err != nil {
+		return Profile{}, err
+	}
+	if !found {
+		return Profile{}, ErrProfileNotFound
+	}
+	return profile, nil
+}
+
 // Directory is the public list of mentors.
 func (s *Service) Directory(ctx context.Context, f DirectoryFilter) ([]Profile, error) {
 	if f.Limit <= 0 || f.Limit > maxDirectoryPage {

--- a/internal/engage/mentorship/profile_test.go
+++ b/internal/engage/mentorship/profile_test.go
@@ -597,6 +597,35 @@ func TestReactivateByAStrangerIsRefused(t *testing.T) {
 	}
 }
 
+// A moderator reads a profile by row id regardless of its status — the queue lists
+// pending rows, but the lookup itself carries no status guard: the caller (an id from a
+// moderator's own queue read) already establishes the context.
+func TestProfileForModerationReadsAnyStatus(t *testing.T) {
+	repo := newFakeRepo()
+	svc := newTestService(t, repo)
+	submitted, err := svc.SubmitProfile(context.Background(), validInput())
+	if err != nil {
+		t.Fatalf("SubmitProfile: %v", err)
+	}
+
+	got, err := svc.ProfileForModeration(context.Background(), submitted.ID)
+	if err != nil {
+		t.Fatalf("ProfileForModeration: %v", err)
+	}
+	if got.ID != submitted.ID || got.Status != StatusPending {
+		t.Errorf("got id=%d status=%q, want id=%d status=%q", got.ID, got.Status, submitted.ID, StatusPending)
+	}
+}
+
+func TestProfileForModerationRefusesAnUnknownID(t *testing.T) {
+	repo := newFakeRepo()
+	svc := newTestService(t, repo)
+
+	if _, err := svc.ProfileForModeration(context.Background(), 999999); !errors.Is(err, ErrProfileNotFound) {
+		t.Errorf("error = %v, want ErrProfileNotFound", err)
+	}
+}
+
 // ShowPhoto defaults off and round-trips through both create and update, independent
 // of every other field — a mentor's own opt-in, not a byproduct of anything else they
 // submit.

--- a/openspec/changes/mentor-moderation-preview/.openspec.yaml
+++ b/openspec/changes/mentor-moderation-preview/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/mentor-moderation-preview/design.md
+++ b/openspec/changes/mentor-moderation-preview/design.md
@@ -1,0 +1,79 @@
+## Context
+
+See proposal.md - Why. Relevant existing shapes:
+
+- `mentorResponse` (`internal/api/handler/mentorship.go`) is the one wire shape shared by
+  the public read, the owner's cabinet read, and the moderator's queue read —
+  `toMentorResponse` → `toModeratorMentorResponse` (+status/paused) →
+  `toOwnMentorResponse` (+meeting link/session logistics). `CreatedAt` is on
+  `mentorship.Profile` and selected by the SQL, but no `to*Response` function sets it.
+- `GetMentorPhoto` resolves the profile via `Service.PublicProfile`, which reads through
+  `PublishedProfileBySlug` — `status = 'approved' AND NOT paused` in the query itself.
+  There is no existing by-id, any-status profile read on `Service` (only on
+  `Repository`, used internally by booking/withdrawal code paths).
+- The moderation queue (`ListPendingMentorProfiles`) already returns everything a
+  preview needs except the photo: name, headline, company, bio, topics, languages,
+  timezone, session_minutes, show_photo.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A moderator can see when a profile was submitted and preview its opted-in photo.
+- The public photo/profile routes keep refusing an unapproved profile exactly as today.
+
+**Non-Goals:**
+- No shared component with the public `/mentors/[slug]` page — the moderation preview is
+  a separate, purpose-built rendering (no booking widget, no rating display worth
+  showing on a profile with zero reviews).
+- No change to what the public directory, public profile read, or public photo route
+  return — this only adds a moderator-scoped path.
+- No pagination/history of past decisions on a profile — out of scope for "what to
+  review right now."
+
+## Decisions
+
+**`created_at` is added to the shared `mentorResponse` struct field, populated only by
+`toModeratorMentorResponse` and `toOwnMentorResponse` — never by the plain
+`toMentorResponse` the public routes use.**
+Adding the field to the shared struct (rather than a queue-specific wrapper type) mirrors
+how `status`/`paused` already work: one struct, `omitempty`, populated selectively by the
+function that builds a given audience's view. `toMentorResponse` never sets it, so the
+public directory and public profile read are unaffected without needing a guard.
+
+**A new `Service.ProfileForModeration(ctx, id)` wraps `Repository.ProfileByID`
+unconditionally — no status filter, no ownership check.**
+The route it backs is already behind `mw.moderator`, which is the only access control
+this needs; duplicating a check the middleware already makes would be the kind of second
+copy that drifts. This mirrors `Service.Decide`, which also takes a bare id under the
+same middleware gate.
+
+**The new photo route lives beside the existing moderator routes:
+`GET /mentorship/profiles/:id/photo`, not `/me/mentorship/...`.**
+The `/me/...` prefix names routes under the CALLER's own cabinet; `/mentorship/profiles`
+is already the moderator queue's own namespace (`GET /mentorship/profiles`, `POST
+/mentorship/profiles/:id/decide`), keyed by the numeric row id a moderator already reads
+off the queue, not by slug (a slug the moderator would have to know is not yet public).
+
+**The frontend preview reuses the queue's already-fetched `PendingMentorProfile`; only
+the photo needs a network call.**
+Every other field the preview shows (name, headline, company, topics, languages, bio) is
+already in the list response — building a second "read one profile" endpoint just to
+re-fetch what's already in hand would be a round trip for nothing.
+
+## Risks / Trade-offs
+
+- [A moderator's own photo route duplicates `GetMentorPhoto`'s shape] → Both call the
+  same `mentorPhoto(ctx, profile, photos)` helper; only the profile lookup differs
+  (`ProfileForModeration` vs `PublicProfile`), so the duplication is the handler
+  boilerplate around one shared helper, not the photo-serving logic itself.
+- [Two visually different "how does this mentor look" renderings (public page, moderator
+  preview) could drift in what fields they show] → Accepted for now per Non-Goals; the
+  moderator's job is deciding whether to publish, not proofreading the exact public
+  layout, and unifying them would touch the already-shipped public route for a benefit
+  this change does not need.
+
+## Migration Plan
+
+No schema change. `created_at` already exists and is already selected by
+`ListPendingMentorProfiles`; this only stops the handler from discarding it. Deploys
+without any coordination.

--- a/openspec/changes/mentor-moderation-preview/proposal.md
+++ b/openspec/changes/mentor-moderation-preview/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+A moderator deciding on a pending mentor profile currently sees only name, headline,
+company, bio, topics, languages and a referral-offer flag (`GET
+/api/v1/mentorship/profiles`) — no submission date, and no way to see how the profile
+will actually look once published. The public mentor page cannot be reused for this: it
+fetches through the public `GET /api/v1/mentors/:slug` endpoint, which 404s for any
+non-approved profile by design (so a visitor cannot enumerate the moderation queue), and
+its photo endpoint has the same gate. A moderator is left approving or rejecting a
+profile they cannot actually preview.
+
+## What Changes
+
+- The moderator-facing response for a pending profile now carries `created_at`, already
+  read by the SQL query and carried on the domain type, but previously dropped before
+  serialization.
+- A new moderator-only route, `GET /mentorship/profiles/:id/photo`, serves a pending
+  mentor's opted-in photo by resolving the profile through a new
+  `Service.ProfileForModeration` (unconditional lookup by id) instead of the public-only
+  `PublicProfile`.
+- The moderation queue UI shows each profile's submission date and offers a "Preview"
+  toggle rendering a public-card-style view (photo, name, headline @ company,
+  topics/languages, bio) from data the queue already holds, plus the new photo route.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `mentor-profile`: a moderator's read of a pending profile now includes its submission
+  date and a way to preview its would-be-public photo.
+
+## Impact
+
+- `internal/api/handler/mentorship.go`: `mentorResponse`/`toModeratorMentorResponse`
+  gains `created_at`; new `GetPendingMentorPhoto` handler + route.
+- `internal/engage/mentorship/{profile,service}.go`: new `Service.ProfileForModeration`.
+- `web/src/lib/api.ts`, `web/src/lib/components/MentorReviewView.svelte`: submission
+  date display, preview toggle, moderator photo fetch.
+- No schema change, no migration: `created_at` already exists and is already selected by
+  `ListPendingMentorProfiles`.

--- a/openspec/changes/mentor-moderation-preview/specs/mentor-profile/spec.md
+++ b/openspec/changes/mentor-moderation-preview/specs/mentor-profile/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: A profile reaches the public only through manual moderation
+
+A submitted profile SHALL begin at status `pending` and SHALL become publicly visible
+only when a moderator sets it to `approved`. The system SHALL NOT infer approval from
+any other signal, including an approved `referral_offers` row for the same account and
+company. A moderator SHALL be able to reject a profile and SHALL be able to move an
+approved profile back out of the public listing.
+
+The moderation queue's read of a pending profile SHALL include when it was submitted,
+and SHALL let a moderator preview the profile's opted-in photo — without exposing it
+through the public, slug-keyed photo route, which SHALL continue to answer as though an
+unapproved profile does not exist.
+
+#### Scenario: A submitted profile is not yet listed
+
+- **WHEN** a user submits a mentor profile
+- **THEN** its status is `pending`
+- **AND** it appears in the moderation queue, oldest first
+- **AND** it does not appear in the public directory
+
+#### Scenario: An approved referral offer does not auto-approve a profile
+
+- **WHEN** a user with an approved `referral_offers` row for company X submits a
+  mentor profile for company X
+- **THEN** the profile status is still `pending`
+- **AND** the moderation queue marks the corroborating referral offer as evidence
+
+#### Scenario: A moderator approves a profile
+
+- **WHEN** a moderator approves a pending profile
+- **THEN** the status becomes `approved` and the deciding moderator and time are recorded
+- **AND** the profile appears in the public directory and at its public URL
+
+#### Scenario: The queue reports when a profile was submitted
+
+- **WHEN** a moderator reads the pending queue
+- **THEN** each entry carries the time its profile was submitted
+
+#### Scenario: A moderator can preview a pending profile's opted-in photo
+
+- **WHEN** a moderator requests the photo of a pending profile that opted in
+  (`show_photo`)
+- **THEN** the photo is served to the moderator
+
+#### Scenario: The public photo route still refuses an unapproved profile
+
+- **WHEN** a signed-out visitor requests a pending or rejected profile's photo through
+  the public, slug-keyed route
+- **THEN** the response is as though the profile does not exist

--- a/openspec/changes/mentor-moderation-preview/tasks.md
+++ b/openspec/changes/mentor-moderation-preview/tasks.md
@@ -1,0 +1,34 @@
+## 1. Backend: expose submission date
+
+- [x] 1.1 Add `CreatedAt time.Time` (JSON `created_at`, `omitempty` via zero-check or a pointer) to `mentorResponse` in `internal/api/handler/mentorship.go`.
+- [x] 1.2 Set it in `toModeratorMentorResponse` and `toOwnMentorResponse`; leave `toMentorResponse` (public) untouched.
+
+## 2. Backend: moderator photo route
+
+- [x] 2.1 Add `Service.ProfileForModeration(ctx, id int64) (Profile, error)` in `internal/engage/mentorship/profile.go`, wrapping `repo.ProfileByID` (0 rows → `ErrProfileNotFound`).
+- [x] 2.2 Add handler `GetPendingMentorPhoto` in `internal/api/handler/mentorship.go` (or `mentorship_write.go`, matching where the other moderator handlers live): resolve via `ProfileForModeration`, reuse the existing `mentorPhoto` helper, mirror `GetMentorPhoto`'s response handling.
+- [x] 2.3 Register `GET /mentorship/profiles/:id/photo` behind `mw.key, mw.moderator` in `internal/api/handler/mentorship.go`'s `register`.
+
+## 3. Tests (test-first per task)
+
+- [x] 3.1 `internal/engage/mentorship/profile_test.go`: `ProfileForModeration` returns a pending profile by id regardless of status; returns `ErrProfileNotFound` for an unknown id.
+- [x] 3.2 `internal/api/handler` integration test: moderator photo route serves a pending, opted-in mentor's photo (200); 404 for a mentor with `show_photo=false`; 404 for an unknown id; 401/403 for a non-moderator caller.
+- [x] 3.3 Confirm (via an existing or new test) that `GET /api/v1/mentors/:slug` and `GET /api/v1/mentors/:slug/photo` are unaffected — still 404 for a pending/rejected profile. Covered by the existing, unmodified `TestOnlyApprovedUnpausedMentorsArePublished` (`internal/platform/db/mentorship_integration_test.go`) — re-ran it green; `GetMentor`/`GetMentorPhoto`/`PublicProfile`/`PublishedProfileBySlug` were not touched by this change.
+
+## 4. Frontend
+
+- [x] 4.1 `web/src/lib/types.ts`: extend `PendingMentorProfile` with `created_at`. No new api.ts function for the photo URL — the existing public page inlines its photo URL template directly (`web/src/routes/mentors/[slug]/+page.svelte:24`) rather than going through an api.ts helper, so the moderator preview follows the same convention: `/api/v1/mentorship/profiles/${profile.id}/photo` inline in the `<img>` src.
+- [x] 4.2 `web/src/lib/components/MentorReviewView.svelte`: show each card's submission date (via the existing `formatDate` from `$lib/utils`, matching the convention other `created_at` displays already use).
+- [x] 4.3 Add a "Preview" toggle per card that renders a public-card-style block (photo when `show_photo`, name, headline @ company, topics/languages chips, bio) from the already-fetched `PendingMentorProfile`, fetching only the photo. A photo load error hides the image (matches the public card's own `show_photo` error-hiding rule).
+- [x] 4.4 Manually verify in the browser: submit a profile with a photo opted in, open the moderation queue, confirm the submission date shows and the preview renders the photo and matching fields. Verified live via `make up` + Playwright against the containerized app: "Submitted Sep 9, 2026" shows in the card header, "Preview" expands a block with the uploaded photo (served through the new moderator-only route), name, headline @ company, topics/languages, and bio.
+
+## 5. Verification
+
+- [x] 5.1 `gofmt -l .` clean on touched Go files.
+- [x] 5.2 `go build ./... && go vet ./...`
+- [x] 5.3 `go test ./...`
+- [x] 5.4 `go vet -tags=integration ./...`
+- [x] 5.5 `go test -tags=integration ./internal/api/handler/ ./internal/engage/mentorship/...`
+- [x] 5.6 `golangci-lint run --new-from-merge-base=origin/main` — clean after fixing bodyclose in the new integration test (same wrapper-hides-Close pitfall as the previous change; fixed the same way, explicit close at each call site).
+- [x] 5.7 `pnpm run check` (web) — 0 errors.
+- [x] 5.8 `openspec validate --strict mentor-moderation-preview`

--- a/web/src/lib/components/MentorReviewView.svelte
+++ b/web/src/lib/components/MentorReviewView.svelte
@@ -4,6 +4,7 @@
   import { AsyncData } from '$lib/asyncData.svelte';
   import { Badge, Button, Card } from '$lib/ui';
   import type { PendingMentorProfile } from '$lib/types';
+  import { SvelteSet } from 'svelte/reactivity';
   import States from './States.svelte';
 
   const queueData = new AsyncData<PendingMentorProfile[]>([]);
@@ -20,19 +21,17 @@
 
   // Which cards have their public-preview expanded. A set of ids rather than one flag,
   // so opening one profile's preview does not close another's.
-  let previewing = $state<Set<number>>(new Set());
+  const previewing = new SvelteSet<number>();
   // A photo load failure (unopted-in, or genuinely missing) hides the image rather than
   // showing a broken-image icon — the same rule the public card follows.
-  let photoFailed = $state<Set<number>>(new Set());
+  const photoFailed = new SvelteSet<number>();
 
   function togglePreview(id: number) {
-    const next = new Set(previewing);
-    if (next.has(id)) {
-      next.delete(id);
+    if (previewing.has(id)) {
+      previewing.delete(id);
     } else {
-      next.add(id);
+      previewing.add(id);
     }
-    previewing = next;
   }
 
   async function decide(profile: PendingMentorProfile, next: 'approved' | 'rejected') {
@@ -119,7 +118,7 @@
                     src={`/api/v1/mentorship/profiles/${profile.id}/photo`}
                     alt=""
                     class="h-16 w-16 shrink-0 rounded-full object-cover"
-                    onerror={() => (photoFailed = new Set(photoFailed).add(profile.id))}
+                    onerror={() => photoFailed.add(profile.id)}
                   />
                 {/if}
                 <div class="flex flex-col gap-2">

--- a/web/src/lib/components/MentorReviewView.svelte
+++ b/web/src/lib/components/MentorReviewView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { api } from '$lib/api';
-  import { errorMessage } from '$lib/utils';
+  import { errorMessage, formatDate } from '$lib/utils';
   import { AsyncData } from '$lib/asyncData.svelte';
   import { Badge, Button, Card } from '$lib/ui';
   import type { PendingMentorProfile } from '$lib/types';
@@ -17,6 +17,23 @@
   // The row currently being decided, so its own buttons disable rather than the whole list.
   let acting = $state<number | null>(null);
   let error = $state<string | null>(null);
+
+  // Which cards have their public-preview expanded. A set of ids rather than one flag,
+  // so opening one profile's preview does not close another's.
+  let previewing = $state<Set<number>>(new Set());
+  // A photo load failure (unopted-in, or genuinely missing) hides the image rather than
+  // showing a broken-image icon — the same rule the public card follows.
+  let photoFailed = $state<Set<number>>(new Set());
+
+  function togglePreview(id: number) {
+    const next = new Set(previewing);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    previewing = next;
+  }
 
   async function decide(profile: PendingMentorProfile, next: 'approved' | 'rejected') {
     acting = profile.id;
@@ -51,10 +68,15 @@
       {#each queue as profile (profile.id)}
         <li>
           <Card class="flex flex-col gap-3 p-4">
-            <div>
-              <p class="font-medium">{profile.name}</p>
-              <p class="text-muted-foreground text-sm">
-                {profile.headline} · {profile.company_name} ({profile.company_slug})
+            <div class="flex flex-wrap items-baseline justify-between gap-2">
+              <div>
+                <p class="font-medium">{profile.name}</p>
+                <p class="text-muted-foreground text-sm">
+                  {profile.headline} · {profile.company_name} ({profile.company_slug})
+                </p>
+              </div>
+              <p class="text-muted-foreground shrink-0 text-xs">
+                Submitted {formatDate(profile.created_at)}
               </p>
             </div>
 
@@ -78,6 +100,48 @@
               <p class="text-muted-foreground text-sm">
                 Already an approved referrer for this company.
               </p>
+            {/if}
+
+            <div>
+              <Button variant="ghost" size="sm" onclick={() => togglePreview(profile.id)}>
+                {previewing.has(profile.id) ? 'Hide preview' : 'Preview'}
+              </Button>
+            </div>
+
+            <!-- What a visitor will see once this is approved — built from data already in
+                 hand, plus the one thing that isn't: the opted-in photo, served through a
+                 moderator-only route so a pending profile's picture never has to pass
+                 through the public, slug-keyed one. -->
+            {#if previewing.has(profile.id)}
+              <div class="bg-muted/40 flex items-start gap-3 rounded-md border p-3">
+                {#if profile.show_photo && !photoFailed.has(profile.id)}
+                  <img
+                    src={`/api/v1/mentorship/profiles/${profile.id}/photo`}
+                    alt=""
+                    class="h-16 w-16 shrink-0 rounded-full object-cover"
+                    onerror={() => (photoFailed = new Set(photoFailed).add(profile.id))}
+                  />
+                {/if}
+                <div class="flex flex-col gap-2">
+                  <div>
+                    <p class="font-medium">{profile.name}</p>
+                    <p class="text-muted-foreground text-sm">
+                      {profile.headline} · {profile.company_name}
+                    </p>
+                  </div>
+                  <div class="flex flex-wrap gap-1">
+                    {#each profile.topics as topic (topic)}
+                      <Badge variant="secondary">{topic}</Badge>
+                    {/each}
+                    {#each profile.languages as language (language)}
+                      <Badge variant="outline">{language}</Badge>
+                    {/each}
+                  </div>
+                  {#if profile.bio}
+                    <p class="text-sm whitespace-pre-line">{profile.bio}</p>
+                  {/if}
+                </div>
+              </div>
             {/if}
 
             <div class="flex gap-2">

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1762,6 +1762,9 @@ export interface PendingMentorProfile extends Mentor {
   id: number;
   status: string;
   paused: boolean;
+  /** When the profile was submitted (or resubmitted after a withdrawal) — moderator-only,
+   *  ISO 8601. */
+  created_at: string;
   /** Evidence for the human deciding: this account is already an approved referrer for
    *  the same company. Corroboration, never a gate — an approved offer does not approve
    *  a mentor profile, and the spec says so outright. */


### PR DESCRIPTION
## Summary
- The mentor-profile moderation queue showed only name, headline, company, bio, topics, languages and a referral-offer flag — no submission date, and no way to see how the profile will look once published. The public mentor page can't be reused for this: it 404s any non-approved profile by design.
- Adds `created_at` to the moderator/owner response (already selected by the SQL, just dropped before serialization).
- Adds a moderator-only photo route (`GET /mentorship/profiles/:id/photo`) resolved by row id via a new `Service.ProfileForModeration`, so a pending mentor's opted-in photo can be previewed without going through the public, slug-keyed route.
- `MentorReviewView.svelte` shows the submission date and a "Preview" toggle rendering a public-card-style block from data the queue already has.
- OpenSpec change `mentor-moderation-preview` (proposal/design/spec delta/tasks) tracks this; spec delta for `mentor-profile` included.

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `go test ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test -tags=integration ./internal/api/handler/ ./internal/engage/mentorship/...`
- [x] `golangci-lint run --new-from-merge-base=origin/main`
- [x] `pnpm run check` (svelte-check, 0 errors)
- [x] Manually verified live via `make up` + Playwright: submission date shows, "Preview" renders the uploaded photo, name, headline @ company, topics/languages, bio
- [x] Single whole-diff code review (no Critical/Important findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Moderators can see when mentor profiles were submitted or resubmitted.
  * Added a per-profile preview showing how pending mentor profiles will appear publicly once approved.
  * Previews can display opted-in mentor photos through a moderator-only photo view.
* **Access Control**
  * Photo previews are restricted to moderators.
  * Photos remain unavailable for profiles without photo-sharing consent, unknown profiles, and unauthorized viewers.
* **Bug Fixes**
  * Public profile and photo visibility rules continue to exclude unapproved profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->