### PR TITLE
Send each platform to the page its application form is actually on

### DIFF
--- a/internal/api/atsapply/client.go
+++ b/internal/api/atsapply/client.go
@@ -200,7 +200,7 @@ func (c *Client) Submit(ctx context.Context, claimed autoapply.Claimed, answers 
 		}
 		defer cancelBrowser()
 
-		pageHTML, err := renderedHTML(browserCtx, claimed.JobURL, layout.formSelector)
+		pageHTML, err := renderedHTML(browserCtx, layout.applyURL(claimed.JobURL), layout.formSelector)
 		if err != nil {
 			if result, parked := unscannableFormResult(err); parked {
 				return result, nil

--- a/internal/api/atsapply/layout.go
+++ b/internal/api/atsapply/layout.go
@@ -1,6 +1,10 @@
 package atsapply
 
-import "github.com/chromedp/chromedp"
+import (
+	"strings"
+
+	"github.com/chromedp/chromedp"
+)
 
 // addressing is how a platform identifies a control on its own application form — which
 // attribute names it, and therefore which attribute selects it.
@@ -43,6 +47,31 @@ type formLayout struct {
 	submitSelector string
 	// addressBy is how a control on this platform is named, and so how it is selected.
 	addressBy addressing
+	// applyPath is appended to a posting's own URL to reach the page its application form
+	// is on. Empty when the posting URL IS that page.
+	//
+	// Greenhouse renders the description and the form together, so the worker's navigation
+	// target has always been the posting URL itself. Lever renders them on two pages: the
+	// posting URL carries the description and no form at all, and the form is at that URL
+	// plus /apply. A live attempt parked as unrecognized_form_layout because of exactly
+	// that — the page loaded fine and simply had no form on it.
+	applyPath string
+}
+
+// applyURL is the page this platform's application form is on, given the posting's own URL.
+//
+// Idempotent: a URL that already ends in the path (with or without a trailing slash) is
+// returned unchanged, so a stored URL that happens to include it does not gain a second
+// copy.
+func (l formLayout) applyURL(postingURL string) string {
+	if l.applyPath == "" {
+		return postingURL
+	}
+	trimmed := strings.TrimSuffix(postingURL, "/")
+	if strings.HasSuffix(trimmed, l.applyPath) {
+		return postingURL
+	}
+	return trimmed + l.applyPath
 }
 
 // layouts is every platform this package can drive a browser against.
@@ -55,7 +84,7 @@ type formLayout struct {
 // would have to be un-shared under time pressure.
 var layouts = map[string]formLayout{
 	"greenhouse": {formSelector: "application-form", submitSelector: "#submit_app", addressBy: byID},
-	"lever":      {formSelector: "application-form", submitSelector: "#btn-submit", addressBy: byName},
+	"lever":      {formSelector: "application-form", submitSelector: "#btn-submit", addressBy: byName, applyPath: "/apply"},
 }
 
 // queryKind is how chromedp must interpret the selector this addressing produces. It lives

--- a/internal/api/atsapply/layout_test.go
+++ b/internal/api/atsapply/layout_test.go
@@ -29,7 +29,7 @@ func TestLayoutFor_KnowsTheTwoProvidersWithAFillPath(t *testing.T) {
 	if !ok {
 		t.Fatal("lever has no layout")
 	}
-	wantLever := formLayout{formSelector: "application-form", submitSelector: "#btn-submit", addressBy: byName}
+	wantLever := formLayout{formSelector: "application-form", submitSelector: "#btn-submit", addressBy: byName, applyPath: "/apply"}
 	if lv != wantLever {
 		t.Errorf("lever layout = %+v, want %+v", lv, wantLever)
 	}

--- a/internal/api/atsapply/layout_test.go
+++ b/internal/api/atsapply/layout_test.go
@@ -142,3 +142,37 @@ func TestFillOne_EveryActionOnTheSharedSelectorCarriesTheLayoutsQueryKind(t *tes
 		t.Error("no line acting on sel was found; this test is no longer pinned to anything")
 	}
 }
+
+// Lever renders the posting and the application form on two different pages; Greenhouse
+// renders them on one.
+//
+// The worker navigates to the posting's own URL (jobs.url), which for Greenhouse IS the
+// form. On Lever that page carries the description and no form at all — the form lives at
+// the same URL plus /apply. A live attempt on queue entry 6 parked as
+// unrecognized_form_layout for exactly this reason: the page loaded fine and simply had no
+// application form on it (freehire, 2026-09-10).
+func TestApplyURL_SendsEachPlatformToThePageItsFormIsOn(t *testing.T) {
+	gh, _ := layoutFor("greenhouse")
+	const ghPosting = "https://job-boards.greenhouse.io/garnerhealth/jobs/6181651004"
+	if got := gh.applyURL(ghPosting); got != ghPosting {
+		t.Errorf("greenhouse apply url = %q, want the posting URL unchanged", got)
+	}
+
+	lv, _ := layoutFor("lever")
+	const lvPosting = "https://jobs.lever.co/jobgether/08a82436-bd70-48bc-8304-1355c12a74ae"
+	if got := lv.applyURL(lvPosting); got != lvPosting+"/apply" {
+		t.Errorf("lever apply url = %q, want the posting URL plus /apply", got)
+	}
+}
+
+// A posting URL that already ends in the form's path must not gain a second one.
+func TestApplyURL_DoesNotDoubleTheSuffix(t *testing.T) {
+	lv, _ := layoutFor("lever")
+	const alreadyApply = "https://jobs.lever.co/jobgether/08a82436/apply"
+	if got := lv.applyURL(alreadyApply); got != alreadyApply {
+		t.Errorf("apply url = %q, want it unchanged when the path is already there", got)
+	}
+	if got := lv.applyURL(alreadyApply + "/"); got != alreadyApply+"/" {
+		t.Errorf("apply url = %q, want a trailing slash to count as the same path", got)
+	}
+}

--- a/internal/api/atsapply/preview_client.go
+++ b/internal/api/atsapply/preview_client.go
@@ -122,7 +122,7 @@ func (p *PreviewClient) previewByLayout(ctx context.Context, claimed autoapply.C
 		// later caller ends up scanning with a zero-valued layout.
 		return autoapply.PreviewResult{}, fmt.Errorf("no form layout for %q", claimed.Provider)
 	}
-	pageHTML, err := renderedHTML(browserCtx, claimed.JobURL, layout.formSelector)
+	pageHTML, err := renderedHTML(browserCtx, layout.applyURL(claimed.JobURL), layout.formSelector)
 	if err != nil {
 		if result, parked := unscannableFormResult(err); parked {
 			return autoapply.PreviewResult{Parked: true, Reason: result.Reason}, nil


### PR DESCRIPTION
A live Lever attempt parked as `unrecognized_form_layout`. The page loaded fine and simply **had no application form on it**.

The worker navigates to the posting's own URL. On Lever that page carries the description; the form lives at the same URL plus `/apply`. Greenhouse renders both together, so the posting URL has always been the right target and nothing in the package had reason to distinguish them.

The layout registry described three things about a platform's page. This is the fourth — and it is the one that decides which page is even opened.

## How it was found

By approving a real application and watching where it stopped.

The fixture and every live DOM capture used the `/apply` URL directly, because that is the page a person lands on when they click Apply. So neither could have caught this: **a capture taken by hand does not prove the code reaches the same page.**

## Detail

`applyURL` is idempotent — a stored URL already ending in the path, with or without a trailing slash, does not gain a second copy.

Wired at both sites that open a page: the submission path and the preview path, so the candidate's preview and the actual fill cannot land on different pages.

`go test ./...`, `go vet -tags=integration ./...`, `gofmt`, `golangci-lint` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Application submissions and previews now open the correct provider-specific application page.
  - Lever postings are directed to their `/apply` page, including when the URL already contains that path.
  - Greenhouse posting URLs continue to open unchanged.
  - Improved handling of trailing slashes to prevent duplicate application paths.
  - Preview and submission flows now consistently use the appropriate application page across supported providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->