### PR TITLE
Align the stat-tile figures on one baseline

### DIFF
--- a/web/src/lib/components/HomeView.svelte
+++ b/web/src/lib/components/HomeView.svelte
@@ -231,7 +231,7 @@
         <!-- A two-line label must not push its figure down: the cell is a column and the
              figure is pinned to its bottom, so every figure in a row shares one baseline. -->
         <div class="flex flex-col bg-background p-5 sm:p-6">
-          <dt class="font-mono text-xs uppercase tracking-wide text-muted-foreground">{f.label}</dt>
+          <dt class="font-mono text-xs uppercase tracking-wide text-balance text-muted-foreground">{f.label}</dt>
           <dd class="mt-auto pt-2 text-3xl font-semibold tracking-tight tabular-nums sm:text-4xl">{f.value}</dd>
         </div>
       {/each}

--- a/web/src/lib/components/HomeView.svelte
+++ b/web/src/lib/components/HomeView.svelte
@@ -228,9 +228,11 @@
     <SectionLabel text="the catalogue" />
     <dl class="mt-6 grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-4">
       {#each figures as f (f.label)}
-        <div class="bg-background p-5 sm:p-6">
+        <!-- A two-line label must not push its figure down: the cell is a column and the
+             figure is pinned to its bottom, so every figure in a row shares one baseline. -->
+        <div class="flex flex-col bg-background p-5 sm:p-6">
           <dt class="font-mono text-xs uppercase tracking-wide text-muted-foreground">{f.label}</dt>
-          <dd class="mt-2 text-3xl font-semibold tracking-tight tabular-nums sm:text-4xl">{f.value}</dd>
+          <dd class="mt-auto pt-2 text-3xl font-semibold tracking-tight tabular-nums sm:text-4xl">{f.value}</dd>
         </div>
       {/each}
     </dl>

--- a/web/src/routes/contributors/[login]/+page.svelte
+++ b/web/src/routes/contributors/[login]/+page.svelte
@@ -99,11 +99,11 @@
 
   <dl class="mt-8 grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-border bg-border">
     {#each stats as stat (stat.label)}
-      <div class="bg-background p-5">
+      <div class="flex flex-col bg-background p-5">
         <dt class="font-mono text-xs uppercase tracking-wide text-muted-foreground">
           {stat.label}
         </dt>
-        <dd class="mt-2 text-3xl font-semibold tracking-tight tabular-nums">{stat.value}</dd>
+        <dd class="mt-auto pt-2 text-3xl font-semibold tracking-tight tabular-nums">{stat.value}</dd>
       </div>
     {/each}
   </dl>

--- a/web/src/routes/contributors/[login]/+page.svelte
+++ b/web/src/routes/contributors/[login]/+page.svelte
@@ -97,16 +97,21 @@
     </div>
   </header>
 
-  <dl class="mt-8 grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-border bg-border">
-    {#each stats as stat (stat.label)}
-      <div class="flex flex-col bg-background p-5">
-        <dt class="font-mono text-xs uppercase tracking-wide text-muted-foreground">
-          {stat.label}
-        </dt>
-        <dd class="mt-auto pt-2 text-3xl font-semibold tracking-tight tabular-nums">{stat.value}</dd>
-      </div>
-    {/each}
-  </dl>
+  <!-- A contributor who has opened no issues has one tile, so a fixed two-column grid
+       would leave half the strip as an empty cell — a wrapping flex grows the last row's
+       tiles to fill the width instead. -->
+  <div class="mt-8 overflow-hidden rounded-xl border border-border">
+    <dl class="-mb-px -mr-px flex flex-wrap">
+      {#each stats as stat (stat.label)}
+        <div class="flex min-w-36 flex-1 flex-col border-b border-r border-border p-5">
+          <dt class="font-mono text-xs uppercase tracking-wide text-balance text-muted-foreground">
+            {stat.label}
+          </dt>
+          <dd class="mt-auto pt-2 text-3xl font-semibold tracking-tight tabular-nums">{stat.value}</dd>
+        </div>
+      {/each}
+    </dl>
+  </div>
 
   {#if who.recentPullRequests.length > 0}
     <section class="mt-12">

--- a/web/src/routes/open/+page.svelte
+++ b/web/src/routes/open/+page.svelte
@@ -198,9 +198,11 @@
     <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// the catalogue</p>
     <dl class="mt-6 grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-3 lg:grid-cols-5">
       {#each stats as s (s.label)}
-        <div class="bg-background p-5 sm:p-6">
+        <!-- A two-line label must not push its figure down: the cell is a column and the
+             figure is pinned to its bottom, so every figure in a row shares one baseline. -->
+        <div class="flex flex-col bg-background p-5 sm:p-6">
           <dt class="font-mono text-xs uppercase tracking-wide text-muted-foreground">{s.label}</dt>
-          <dd class="mt-2 text-3xl font-semibold tracking-tight tabular-nums sm:text-4xl">
+          <dd class="mt-auto pt-2 text-3xl font-semibold tracking-tight tabular-nums sm:text-4xl">
             {#if s.href}
               <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- links to the JSON API endpoint, not a SvelteKit route -->
               <a href={s.href} class="hover:underline">{s.value}</a>
@@ -260,9 +262,9 @@
     {#if engagement}
       <dl class="grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-4">
         {#each engagement as e (e.label)}
-          <div class="bg-background p-5 sm:p-6">
+          <div class="flex flex-col bg-background p-5 sm:p-6">
             <dt class="font-mono text-xs uppercase tracking-wide text-muted-foreground">{e.label}</dt>
-            <dd class="mt-2 text-3xl font-semibold tracking-tight tabular-nums sm:text-4xl">{e.value}</dd>
+            <dd class="mt-auto pt-2 text-3xl font-semibold tracking-tight tabular-nums sm:text-4xl">{e.value}</dd>
           </div>
         {/each}
       </dl>

--- a/web/src/routes/open/+page.svelte
+++ b/web/src/routes/open/+page.svelte
@@ -196,23 +196,31 @@
   <!-- A. Catalogue scale -->
   <section class="mb-14">
     <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// the catalogue</p>
-    <dl class="mt-6 grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-3 lg:grid-cols-5">
-      {#each stats as s (s.label)}
-        <!-- A two-line label must not push its figure down: the cell is a column and the
-             figure is pinned to its bottom, so every figure in a row shares one baseline. -->
-        <div class="flex flex-col bg-background p-5 sm:p-6">
-          <dt class="font-mono text-xs uppercase tracking-wide text-muted-foreground">{s.label}</dt>
-          <dd class="mt-auto pt-2 text-3xl font-semibold tracking-tight tabular-nums sm:text-4xl">
-            {#if s.href}
-              <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- links to the JSON API endpoint, not a SvelteKit route -->
-              <a href={s.href} class="hover:underline">{s.value}</a>
-            {:else}
-              {s.value}
-            {/if}
-          </dd>
-        </div>
-      {/each}
-    </dl>
+    <!-- Wrapping flex, not a fixed grid: the strip holds five figures and drops any the
+         snapshot could not measure, so a fixed column count leaves a hole in the last row
+         — and with the separators drawn by the container's own colour showing through a
+         one-pixel gap, that hole rendered as a grey block. Here the last row's tiles grow
+         to fill the width instead. The tiles' own borders draw the separators, and the
+         negative margin pushes the outermost ones under the container's clipped edge. -->
+    <div class="mt-6 overflow-hidden rounded-xl border border-border">
+      <dl class="-mb-px -mr-px flex flex-wrap">
+        {#each stats as s (s.label)}
+          <!-- A two-line label must not push its figure down: the tile is a column and the
+               figure is pinned to its bottom, so every figure in a row shares one baseline. -->
+          <div class="flex min-w-36 flex-1 flex-col border-b border-r border-border p-5 sm:p-6">
+            <dt class="font-mono text-xs uppercase tracking-wide text-balance text-muted-foreground">{s.label}</dt>
+            <dd class="mt-auto pt-2 text-3xl font-semibold tracking-tight tabular-nums sm:text-4xl">
+              {#if s.href}
+                <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- links to the JSON API endpoint, not a SvelteKit route -->
+                <a href={s.href} class="hover:underline">{s.value}</a>
+              {:else}
+                {s.value}
+              {/if}
+            </dd>
+          </div>
+        {/each}
+      </dl>
+    </div>
   </section>
 
   <!-- B. Catalogue movement -->
@@ -263,7 +271,7 @@
       <dl class="grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-4">
         {#each engagement as e (e.label)}
           <div class="flex flex-col bg-background p-5 sm:p-6">
-            <dt class="font-mono text-xs uppercase tracking-wide text-muted-foreground">{e.label}</dt>
+            <dt class="font-mono text-xs uppercase tracking-wide text-balance text-muted-foreground">{e.label}</dt>
             <dd class="mt-auto pt-2 text-3xl font-semibold tracking-tight tabular-nums sm:text-4xl">{e.value}</dd>
           </div>
         {/each}


### PR DESCRIPTION
A stat tile put its figure directly under its label, so a label that wrapped to two lines ("unique jobs to browse") pushed its number half a line below the numbers beside it — the catalogue strip read as a staircase.

The tile is now a column with the figure pinned to its bottom (`flex flex-col` + `mt-auto`). Grid cells already stretch to the tallest in the row, so every figure in a row lands on one baseline no matter how many lines its label takes — and it keeps working if a label ever wraps to three.

Same shape, same defect, fixed in all four places it lives: both strips on `/open`, the homepage catalogue strip, and a contributor's page. `HomeLandingView` is untouched — its tile is `flex-col-reverse` with the number on top, which is already immune.

CSS only; no behaviour, no data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved statistic and catalogue layouts so figures align consistently along the bottom of their cells.
  * Prevented multi-line labels from shifting figures downward, creating more uniform rows across home, contributor, and open startup pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->