### PR TITLE
Carry the board's own words back with a refused submission

### DIFF
--- a/internal/api/atsapply/fill.go
+++ b/internal/api/atsapply/fill.go
@@ -48,6 +48,25 @@ var submitRefusedMarkers = []string{
 	"there was an error",
 }
 
+// refusalEvidenceWindow is how much of the page text either side of a refusal marker is
+// carried back. Wide enough for the sentence the marker sits in — which is where a board
+// says what it actually objected to — and narrow enough to stay one readable line in a
+// queue row's last_error.
+const refusalEvidenceWindow = 140
+
+// refusalEvidence returns the page text around a matched refusal marker, collapsed onto one
+// line. A marker names this package's own detector; the board's reason is in the sentence
+// beside it, and without that sentence the only way to learn it is a second real submission.
+func refusalEvidence(bodyText, marker string) string {
+	i := strings.Index(strings.ToLower(bodyText), marker)
+	if i < 0 {
+		return ""
+	}
+	start := max(0, i-refusalEvidenceWindow)
+	end := min(len(bodyText), i+len(marker)+refusalEvidenceWindow)
+	return strings.Join(strings.Fields(bodyText[start:end]), " ")
+}
+
 // fillAndSubmit fills every field the plan resolved, presses submit, and reports whether
 // the submission was confirmed. It runs on an already-navigated page (the same session
 // renderedHTML used to scan the form) — config always wins here in the sense that matters
@@ -193,7 +212,7 @@ func verifySubmission(parent context.Context) (bool, error) {
 		}
 		for _, m := range submitRefusedMarkers {
 			if strings.Contains(lower, m) {
-				return false, fmt.Errorf("board refused the submission: matched marker %q", m)
+				return false, fmt.Errorf("board refused the submission: matched marker %q in %q", m, refusalEvidence(bodyText, m))
 			}
 		}
 		select {

--- a/internal/api/atsapply/fill_refusal_test.go
+++ b/internal/api/atsapply/fill_refusal_test.go
@@ -1,0 +1,44 @@
+package atsapply
+
+import (
+	"strings"
+	"testing"
+)
+
+// A refusal names our own detector, not the board's reason. The one time this fired on a
+// live Lever posting the operator learned only that "please try again" appeared somewhere
+// on the page — which sentence said it, and therefore what the board actually objected to,
+// cost a second real submission to discover. A submit click cannot be withdrawn, so the
+// evidence has to come back with the first one.
+func TestRefusalEvidence_CarriesTheSentenceAroundTheMarker(t *testing.T) {
+	body := "Apply for Staff Engineer\n\nWe could not process your resume. Please try again with a PDF or DOCX file.\n\nPowered by Lever"
+
+	got := refusalEvidence(body, "please try again")
+
+	for _, want := range []string{"could not process your resume", "PDF or DOCX"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("evidence = %q, want it to carry %q", got, want)
+		}
+	}
+}
+
+// The page text is the whole rendered document — on a real posting, tens of kilobytes of
+// description. All of it lands in the queue row's last_error, which an operator reads in a
+// terminal.
+func TestRefusalEvidence_IsBounded(t *testing.T) {
+	body := strings.Repeat("x", 5_000) + " please try again " + strings.Repeat("y", 5_000)
+
+	if got := refusalEvidence(body, "please try again"); len(got) > 400 {
+		t.Fatalf("evidence length = %d, want it bounded well under the page", len(got))
+	}
+}
+
+// Collapsed, because the page text arrives full of the newlines and runs of spaces the
+// layout put there, and a log line broken across forty lines is not read.
+func TestRefusalEvidence_CollapsesWhitespace(t *testing.T) {
+	body := "Resume\n\n\n   missing.\n\tPlease try again\n\n   now."
+
+	if got := refusalEvidence(body, "please try again"); strings.ContainsAny(got, "\n\t") || strings.Contains(got, "  ") {
+		t.Fatalf("evidence = %q, want it collapsed onto one line", got)
+	}
+}


### PR DESCRIPTION
A refused auto-apply submission recorded `matched marker "please try again"` — this package's own detector, with no trace of what the board objected to. That happened on a live Lever posting tonight, and the only way to learn the reason was to submit again for real.

`verifySubmission` now includes the sentence around the marker: a bounded window, whitespace collapsed, so it stays one readable line in the queue row's `last_error`.

Three tests: the evidence carries the surrounding sentence, it is bounded well under a page, and it is collapsed onto one line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Board-refusal errors now include a concise excerpt of the surrounding page text, making submission failures easier to understand and troubleshoot.

- **Tests**
  - Added coverage to verify that refusal evidence includes relevant context, remains within a reasonable length, and is presented as a single line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->