### PR TITLE
Retry a captcha refusal instead of burying the application

### DIFF
--- a/internal/api/atsapply/captcha_refusal_test.go
+++ b/internal/api/atsapply/captcha_refusal_test.go
@@ -1,0 +1,53 @@
+package atsapply
+
+import (
+	"errors"
+	"testing"
+)
+
+// The one refusal a board states so plainly that retrying it is safe: it says it could not
+// verify the submission, which means it did not accept one. Lever's own wording, read off a
+// live posting on 2026-09-10.
+func TestCaptchaRefusal_RecognisesTheBoardSayingItCouldNotVerify(t *testing.T) {
+	cases := []string{
+		"There was an error verifying your application. Please try again.",
+		"there was an error verifying your submission. please try again",
+		"We could not verify that you are human. Please try again.",
+	}
+	for _, body := range cases {
+		if !isCaptchaRefusal(body) {
+			t.Errorf("isCaptchaRefusal(%q) = false, want true", body)
+		}
+	}
+}
+
+// Everything else stays an ordinary refusal. A board that objected to the RESUME, or to a
+// field, has read the submission — treating that as a captcha refusal would retry it twenty
+// times against a board that will answer identically twenty times.
+func TestCaptchaRefusal_LeavesOtherRefusalsAlone(t *testing.T) {
+	cases := []string{
+		"There was an error uploading your resume. Please try again.",
+		"There was an error. Please try again later.",
+		"Thank you for applying",
+		"",
+	}
+	for _, body := range cases {
+		if isCaptchaRefusal(body) {
+			t.Errorf("isCaptchaRefusal(%q) = true, want false", body)
+		}
+	}
+}
+
+// The refusal travels as an error out of fillAndSubmit, so the client has to recognise it
+// through errors.Is rather than by matching text a second time.
+func TestCaptchaRefusal_TravelsAsAWrappedSentinel(t *testing.T) {
+	err := newRefusalError("please try again", "There was an error verifying your application. Please try again.")
+
+	if !errors.Is(err, errCaptchaRefused) {
+		t.Fatalf("err = %v, want it to wrap errCaptchaRefused", err)
+	}
+	plain := newRefusalError("please try again", "There was an error uploading your resume.")
+	if errors.Is(plain, errCaptchaRefused) {
+		t.Errorf("a resume refusal wraps errCaptchaRefused, want it to stay an ordinary failure")
+	}
+}

--- a/internal/api/atsapply/client.go
+++ b/internal/api/atsapply/client.go
@@ -273,6 +273,14 @@ func (c *Client) Submit(ctx context.Context, claimed autoapply.Claimed, answers 
 
 	confirmed, err := fillAndSubmit(browserCtx, plan, layout)
 	if err != nil {
+		if errors.Is(err, errCaptchaRefused) {
+			// The board said it could not VERIFY the submission, which is it telling us
+			// no application was created. Reported as its own status rather than an
+			// error, because the runner retries this one on a far more generous budget:
+			// an invisible captcha is a coin toss no browser configuration improves, and
+			// each further ask is free of consequence to the employer.
+			return autoapply.SidecarResult{Status: autoapply.StatusCaptchaRefused, Reason: err.Error()}, nil
+		}
 		// A fill action failing, or the board EXPLICITLY refusing the submit click
 		// (SUBMIT_REFUSED_MARKERS in fill.go), both mean no submission happened — safe
 		// to retry normally. This is deliberately distinct from the timeout-with-no-

--- a/internal/api/atsapply/fill.go
+++ b/internal/api/atsapply/fill.go
@@ -2,6 +2,7 @@ package atsapply
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -46,6 +47,41 @@ var confirmationMarkers = []string{
 var submitRefusedMarkers = []string{
 	"please try again",
 	"there was an error",
+}
+
+// errCaptchaRefused marks the one refusal that is safe to retry. A board that says it could
+// not VERIFY the submission is telling us it did not accept one — no application exists, so
+// asking again costs the employer nothing. Every other post-submit uncertainty must not be
+// retried, because it might mean the opposite.
+var errCaptchaRefused = errors.New("captcha refused the submission")
+
+// captchaRefusalMarkers are the boards' own wordings for a failed captcha verification.
+// Deliberately narrow: each requires the word "verify"/"verifying" beside the failure, so a
+// board objecting to the résumé or a field — which it could only do having READ the
+// submission — stays an ordinary refusal.
+var captchaRefusalMarkers = []string{
+	"error verifying your",
+	"could not verify",
+	"couldn't verify",
+	"unable to verify",
+	"verification failed",
+}
+
+// isCaptchaRefusal reports whether the page text is a board declining to verify rather than
+// declining the content of the application.
+func isCaptchaRefusal(bodyText string) bool {
+	return containsAny(strings.ToLower(bodyText), captchaRefusalMarkers)
+}
+
+// newRefusalError builds the error a matched refusal marker travels as: the marker that
+// fired, the board's own sentence around it, and — when the board declined to verify — the
+// errCaptchaRefused sentinel the runner reads with errors.Is.
+func newRefusalError(marker, bodyText string) error {
+	err := fmt.Errorf("board refused the submission: matched marker %q in %q", marker, refusalEvidence(bodyText, marker))
+	if isCaptchaRefusal(bodyText) {
+		return fmt.Errorf("%w: %w", errCaptchaRefused, err)
+	}
+	return err
 }
 
 // refusalEvidenceWindow is how much of the page text either side of a refusal marker is
@@ -212,7 +248,7 @@ func verifySubmission(parent context.Context) (bool, error) {
 		}
 		for _, m := range submitRefusedMarkers {
 			if strings.Contains(lower, m) {
-				return false, fmt.Errorf("board refused the submission: matched marker %q in %q", m, refusalEvidence(bodyText, m))
+				return false, newRefusalError(m, bodyText)
 			}
 		}
 		select {

--- a/internal/api/atsapply/fill.go
+++ b/internal/api/atsapply/fill.go
@@ -48,6 +48,25 @@ var submitRefusedMarkers = []string{
 	"there was an error",
 }
 
+// refusalEvidenceWindow is how much of the page text either side of a refusal marker is
+// carried back. Wide enough for the sentence the marker sits in — which is where a board
+// says what it actually objected to — and narrow enough to stay one readable line in a
+// queue row's last_error.
+const refusalEvidenceWindow = 140
+
+// refusalEvidence returns the page text around a matched refusal marker, collapsed onto one
+// line. A marker names this package's own detector; the board's reason is in the sentence
+// beside it, and without that sentence the only way to learn it is a second real submission.
+func refusalEvidence(bodyText, marker string) string {
+	i := strings.Index(strings.ToLower(bodyText), marker)
+	if i < 0 {
+		return ""
+	}
+	start := max(0, i-refusalEvidenceWindow)
+	end := min(len(bodyText), i+len(marker)+refusalEvidenceWindow)
+	return strings.Join(strings.Fields(bodyText[start:end]), " ")
+}
+
 // fillAndSubmit fills every field the plan resolved, presses submit, and reports whether
 // the submission was confirmed. It runs on an already-navigated page (the same session
 // renderedHTML used to scan the form) — config always wins here in the sense that matters
@@ -193,7 +212,7 @@ func verifySubmission(parent context.Context) (bool, error) {
 		}
 		for _, m := range submitRefusedMarkers {
 			if strings.Contains(lower, m) {
-				return false, fmt.Errorf("board refused the submission: matched marker %q", m)
+				return false, fmt.Errorf("board refused the submission: matched marker %q in %q", m, refusalEvidence(bodyText, m))
 			}
 		}
 		select {

--- a/internal/api/atsapply/fill_refusal_test.go
+++ b/internal/api/atsapply/fill_refusal_test.go
@@ -1,0 +1,44 @@
+package atsapply
+
+import (
+	"strings"
+	"testing"
+)
+
+// A refusal names our own detector, not the board's reason. The one time this fired on a
+// live Lever posting the operator learned only that "please try again" appeared somewhere
+// on the page — which sentence said it, and therefore what the board actually objected to,
+// cost a second real submission to discover. A submit click cannot be withdrawn, so the
+// evidence has to come back with the first one.
+func TestRefusalEvidence_CarriesTheSentenceAroundTheMarker(t *testing.T) {
+	body := "Apply for Staff Engineer\n\nWe could not process your resume. Please try again with a PDF or DOCX file.\n\nPowered by Lever"
+
+	got := refusalEvidence(body, "please try again")
+
+	for _, want := range []string{"could not process your resume", "PDF or DOCX"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("evidence = %q, want it to carry %q", got, want)
+		}
+	}
+}
+
+// The page text is the whole rendered document — on a real posting, tens of kilobytes of
+// description. All of it lands in the queue row's last_error, which an operator reads in a
+// terminal.
+func TestRefusalEvidence_IsBounded(t *testing.T) {
+	body := strings.Repeat("x", 5_000) + " please try again " + strings.Repeat("y", 5_000)
+
+	if got := refusalEvidence(body, "please try again"); len(got) > 400 {
+		t.Fatalf("evidence length = %d, want it bounded well under the page", len(got))
+	}
+}
+
+// Collapsed, because the page text arrives full of the newlines and runs of spaces the
+// layout put there, and a log line broken across forty lines is not read.
+func TestRefusalEvidence_CollapsesWhitespace(t *testing.T) {
+	body := "Resume\n\n\n   missing.\n\tPlease try again\n\n   now."
+
+	if got := refusalEvidence(body, "please try again"); strings.ContainsAny(got, "\n\t") || strings.Contains(got, "  ") {
+		t.Fatalf("evidence = %q, want it collapsed onto one line", got)
+	}
+}

--- a/internal/application/autoapply/runner.go
+++ b/internal/application/autoapply/runner.go
@@ -71,7 +71,29 @@ const (
 	// unconfirmed result is dead-lettered immediately, the same way a lost post-submit
 	// record is, rather than spending a retry.
 	StatusUnconfirmed SubmitStatus = "unconfirmed"
+	// StatusCaptchaRefused means the board answered the submit click by saying, in its own
+	// words, that it could not verify the submission — so no application was created. It is
+	// the ONE post-submit outcome that is safe to retry: every other uncertainty here could
+	// mean the employer already has the application, and StatusUnconfirmed exists precisely
+	// because that possibility must never be retried into a duplicate.
+	StatusCaptchaRefused SubmitStatus = "captcha_refused"
 )
+
+// captchaMaxAttempts is the retry budget for StatusCaptchaRefused, deliberately far more
+// generous than the run's ordinary MaxAttempts.
+//
+// An invisible captcha is not a condition that can be configured away. Eight probe runs
+// against a live Lever posting — headless and windowed under Xvfb, from a datacentre IP and
+// a residential one, with and without mouse/scroll/dwell warm-up, with and without a
+// User-Agent that says "HeadlessChrome" — passed exactly once. Nothing about the browser
+// moved the odds; the pass looked like a coin landing well. What decides whether the
+// application ever goes through is therefore how many times we are willing to ask, and each
+// ask is free of consequence: the board itself said no application was created.
+//
+// 20, against a timer that fires every 5 minutes and takes one attempt per entry, is roughly
+// an hour and a half of asking. Bounded because a posting closes and a person deserves to be
+// told we gave up, rather than a queue that retries silently forever.
+const captchaMaxAttempts = 20
 
 // SidecarResult is what the sidecar returned for one attempt.
 type SidecarResult struct {
@@ -234,6 +256,8 @@ func (rn *run) process(ctx context.Context, c Claimed) outbox.Outcome {
 		return outbox.Discarded
 	case StatusUnconfirmed:
 		return rn.deadLetterImmediately(ctx, c, "submission unconfirmed: neither a confirmation nor a refusal was seen")
+	case StatusCaptchaRefused:
+		return rn.failCaptcha(ctx, c, result.Reason)
 	default:
 		return rn.fail(ctx, c, fmt.Errorf("sidecar returned unknown status %q", result.Status))
 	}
@@ -274,6 +298,27 @@ func (rn *run) deadLetterImmediately(ctx context.Context, c Claimed, reason stri
 		return outbox.Failed
 	}
 	return outbox.DeadLettered
+}
+
+// failCaptcha records a captcha refusal against its own generous budget rather than the
+// run's ordinary one. It is otherwise an ordinary failure — the entry stays claimable, the
+// attempt counts, and running out still dead-letters, which is what tells the candidate we
+// stopped asking rather than leaving them to wonder.
+func (rn *run) failCaptcha(ctx context.Context, c Claimed, boardSaid string) outbox.Outcome {
+	reason := "captcha refused the submission, so no application was created"
+	if boardSaid != "" {
+		reason = fmt.Sprintf("%s: %s", reason, boardSaid)
+	}
+	dead, failErr := rn.store.Fail(ctx, c.QueueID, reason, captchaMaxAttempts)
+	if failErr != nil {
+		log.Printf("auto-apply: record captcha refusal for queue entry %d: %v", c.QueueID, failErr)
+	} else if dead {
+		log.Printf("auto-apply: queue entry %d (job %d) dead-lettered after %d captcha refusals: %s", c.QueueID, c.JobID, captchaMaxAttempts, reason)
+	}
+	if failErr == nil && dead {
+		return outbox.DeadLettered
+	}
+	return outbox.Failed
 }
 
 func (rn *run) fail(ctx context.Context, c Claimed, err error) outbox.Outcome {

--- a/internal/application/autoapply/runner_captcha_test.go
+++ b/internal/application/autoapply/runner_captcha_test.go
@@ -1,0 +1,83 @@
+package autoapply
+
+import (
+	"context"
+	"testing"
+)
+
+// A board that refuses its own captcha verification has told us, in its own words, that it
+// did NOT create an application — which is what makes this the one refusal safe to retry.
+// Every other post-submit uncertainty dead-letters immediately, because retrying it risks a
+// second real application; this one risks nothing.
+//
+// It has to be retried generously, not once: a measurement over eight probe runs against a
+// live Lever posting (headless and windowed, datacentre and residential IP, with and without
+// mouse/scroll warm-up) passed the invisible hCaptcha exactly once. No configuration made it
+// reliable, so what decides whether an application ever goes through is how many times we are
+// willing to ask.
+func TestRunRetriesACaptchaRefusalOnItsOwnGenerousBudget(t *testing.T) {
+	store := &fakeStore{waves: [][]Claimed{{{QueueID: 7, UserID: 10, JobID: 100}}}}
+	answers := &fakeAnswers{answers: map[string]string{}}
+	sidecar := &fakeSidecar{result: SidecarResult{Status: StatusCaptchaRefused}}
+
+	stats, err := Run(context.Background(), store, answers, sidecar, opts())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Failed != 1 {
+		t.Errorf("Failed = %d, want 1 — a captcha refusal is a failed attempt, just a retryable one", stats.Failed)
+	}
+	if len(store.failed) != 1 || store.failed[0] != 7 {
+		t.Fatalf("Store.Fail calls = %v, want [7]", store.failed)
+	}
+	if store.failMax != captchaMaxAttempts {
+		t.Errorf("Fail called with maxAttempts=%d, want captchaMaxAttempts=%d", store.failMax, captchaMaxAttempts)
+	}
+	if store.failMax <= opts().MaxAttempts {
+		t.Errorf("captchaMaxAttempts=%d is not more generous than the ordinary budget %d, which is the whole point", store.failMax, opts().MaxAttempts)
+	}
+}
+
+// The reason recorded on the row is what a person reads when the budget finally runs out, so
+// it must say the captcha refused rather than repeating a raw page fragment.
+func TestRunRecordsWhyACaptchaRefusalHappened(t *testing.T) {
+	store := &fakeStore{waves: [][]Claimed{{{QueueID: 8, UserID: 10, JobID: 100}}}}
+	answers := &fakeAnswers{answers: map[string]string{}}
+	sidecar := &fakeSidecar{result: SidecarResult{Status: StatusCaptchaRefused, Reason: "There was an error verifying your application."}}
+
+	if _, err := Run(context.Background(), store, answers, sidecar, opts()); err != nil {
+		t.Fatal(err)
+	}
+	msg := store.failMsg
+	for _, want := range []string{"captcha", "verifying your application"} {
+		if !containsFold(msg, want) {
+			t.Errorf("recorded reason = %q, want it to mention %q", msg, want)
+		}
+	}
+}
+
+func containsFold(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && indexFold(haystack, needle) >= 0
+}
+
+func indexFold(haystack, needle string) int {
+	lower := func(b byte) byte {
+		if b >= 'A' && b <= 'Z' {
+			return b + 32
+		}
+		return b
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		ok := true
+		for j := range len(needle) {
+			if lower(haystack[i+j]) != lower(needle[j]) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/application/autoapply/runner_test.go
+++ b/internal/application/autoapply/runner_test.go
@@ -20,6 +20,7 @@ type fakeStore struct {
 	failed       []int64
 	failAttempts map[int64]int
 	failMax      int
+	failMsg      string
 	failErr      error
 }
 
@@ -61,6 +62,7 @@ func (f *fakeStore) Fail(ctx context.Context, queueID int64, errMsg string, maxA
 	}
 	f.failAttempts[queueID]++
 	f.failMax = maxAttempts
+	f.failMsg = errMsg
 	return f.failAttempts[queueID] >= maxAttempts, nil
 }
 


### PR DESCRIPTION
A live Lever auto-apply died on its first attempt with the board saying `There was an error verifying your application` — which is Lever telling us it created **no** application. The runner spent the ordinary 3-attempt budget on it and dead-lettered the entry.

**Why this refusal is different.** Every other post-submit uncertainty must not be retried: it might mean the employer already has the application, which is what `StatusUnconfirmed`'s forced dead-letter protects. A refusal to *verify* is the opposite, stated by the board itself.

**Why the budget is 20.** Eight probe runs against a live Lever posting passed the invisible hCaptcha exactly once:

| Where | Mode | Result |
|---|---|---|
| Residential IP | windowed + warm-up | passed (token in 9s) |
| Residential IP | windowed + warm-up (repeat) | challenged |
| Residential IP | windowed, no warm-up | challenged |
| Residential IP | headless | challenged |
| Hetzner | headless | challenged |
| Hetzner | windowed (Xvfb) | challenged |
| Hetzner | windowed + warm-up | challenged |
| Hetzner | headless, honest User-Agent | challenged |

Nothing about the browser moved the odds. What decides whether an application ever goes through is how many times we ask — and each ask is free of consequence. 20 attempts against a 5-minute timer is about 90 minutes of asking, bounded so a candidate is told when we give up.

Recognition is narrow on purpose: every marker requires "verify" beside the failure, so a board objecting to the résumé or a field stays an ordinary refusal. Tests cover both directions plus the sentinel wrapping, and the budget test was verified red-green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CAPTCHA verification refusals are now identified separately from other submission failures.
  - These refusals are recorded with the available explanation and can be retried using a dedicated, more generous retry allowance.

- **Bug Fixes**
  - CAPTCHA-related submission declines no longer appear as generic submission errors.
  - Retry handling now preserves the distinction between retryable CAPTCHA refusals and unrelated application or resume refusals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->