### PR TITLE
Say "captcha refused" once in the recorded reason

### DIFF
--- a/internal/api/atsapply/captcha_message_test.go
+++ b/internal/api/atsapply/captcha_message_test.go
@@ -1,0 +1,25 @@
+package atsapply
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The refusal is recorded on the queue row and read by a person. Wrapping the sentinel with
+// fmt.Errorf("%w: %w", …) put its own sentence in front of the detail, and the runner then
+// prefixed the whole thing again — so the row said "captcha refused the submission" three
+// times before saying anything useful.
+func TestCaptchaRefusalError_SaysItOnce(t *testing.T) {
+	err := newRefusalError("please try again", "There was an error verifying your application. Please try again.")
+
+	if n := strings.Count(err.Error(), "captcha refused"); n != 0 {
+		t.Errorf("error text = %q, want the sentinel's own words %d times, not %d — the runner adds them", err.Error(), 0, n)
+	}
+	if !strings.Contains(err.Error(), "matched marker") {
+		t.Errorf("error text = %q, want it to carry the detail", err.Error())
+	}
+	if !errors.Is(err, errCaptchaRefused) {
+		t.Errorf("error no longer answers errors.Is for the sentinel, which is what the client dispatches on")
+	}
+}

--- a/internal/api/atsapply/fill.go
+++ b/internal/api/atsapply/fill.go
@@ -73,13 +73,23 @@ func isCaptchaRefusal(bodyText string) bool {
 	return containsAny(strings.ToLower(bodyText), captchaRefusalMarkers)
 }
 
+// captchaRefusal carries a refusal that is safe to retry. It answers errors.Is for
+// errCaptchaRefused while reading as the detail alone: the sentinel is a label the client
+// dispatches on, and the runner writes its own sentence in front of it when it records the
+// row. Wrapping with fmt.Errorf("%w: %w", …) instead made the recorded reason say "captcha
+// refused the submission" twice before saying anything a person could act on.
+type captchaRefusal struct{ detail error }
+
+func (e captchaRefusal) Error() string   { return e.detail.Error() }
+func (e captchaRefusal) Unwrap() []error { return []error{errCaptchaRefused, e.detail} }
+
 // newRefusalError builds the error a matched refusal marker travels as: the marker that
 // fired, the board's own sentence around it, and — when the board declined to verify — the
 // errCaptchaRefused sentinel the runner reads with errors.Is.
 func newRefusalError(marker, bodyText string) error {
 	err := fmt.Errorf("board refused the submission: matched marker %q in %q", marker, refusalEvidence(bodyText, marker))
 	if isCaptchaRefusal(bodyText) {
-		return fmt.Errorf("%w: %w", errCaptchaRefused, err)
+		return captchaRefusal{detail: err}
 	}
 	return err
 }


### PR DESCRIPTION
A live queue row recorded:

```
captcha refused the submission, so no application was created: captcha refused the submission: board refused the submission: matched marker "please try again" in "…"
```

The same sentence three deep before the part a person can act on. `fmt.Errorf("%w: %w", sentinel, detail)` renders the sentinel's own text in front of the detail, and the runner adds its own sentence on top of that.

A small error type carries the sentinel for `errors.Is` — which is what the client dispatches on — while reading as the detail alone.