### PR TITLE
Give a captcha refusal its own attempt counter

### DIFF
--- a/cmd/auto-apply/store.go
+++ b/cmd/auto-apply/store.go
@@ -124,6 +124,23 @@ func (s *dbStore) Fail(ctx context.Context, queueID int64, errMsg string, maxAtt
 	return row.FailedAt.Valid, nil
 }
 
+// FailCaptcha is Fail's counterpart for the one refusal safe to retry, on captcha_attempts
+// rather than Fail's attempts (migration 0157). It shares failed_at: running out of asks is
+// still the entry giving up, and the candidate is told the same way. Separating the counter
+// is what stops the captcha's generous budget from spending down the one a genuinely
+// transient error depends on — the same trap FailPreview below already documents.
+func (s *dbStore) FailCaptcha(ctx context.Context, queueID int64, errMsg string, maxAttempts int) (bool, error) {
+	row, err := s.q.RecordAutoApplyCaptchaRefusal(ctx, db.RecordAutoApplyCaptchaRefusalParams{
+		ID:          queueID,
+		LastError:   errMsg,
+		MaxAttempts: int32(maxAttempts),
+	})
+	if err != nil {
+		return false, err
+	}
+	return row.FailedAt.Valid, nil
+}
+
 // FailPreview is Fail's own counterpart for the preview pass, on preview_attempts/
 // preview_failed_at rather than Fail's attempts/failed_at (migration 0140) — a code review
 // caught the two passes sharing one budget, which let a transient preview error dead-letter

--- a/internal/application/autoapply/runner.go
+++ b/internal/application/autoapply/runner.go
@@ -146,6 +146,13 @@ type Store interface {
 	Park(ctx context.Context, queueID int64, unmapped []UnmappedField, reason string) error
 	// Fail records a transient failure for one entry; it reports whether it dead-lettered.
 	Fail(ctx context.Context, queueID int64, errMsg string, maxAttempts int) (deadLettered bool, err error)
+	// FailCaptcha counts a captcha refusal on its own counter (migration 0157) rather
+	// than the ordinary attempts budget. Deliberately NOT Fail with a different
+	// maxAttempts: the two share a column that way, and the captcha's far more generous
+	// budget then spends down the one a genuinely transient error depends on — a live
+	// entry with 12 captcha refusals was dead-lettered by the first field fill that
+	// timed out. Same separation RecordAutoApplyPreviewFailure already makes.
+	FailCaptcha(ctx context.Context, queueID int64, errMsg string, maxAttempts int) (deadLettered bool, err error)
 }
 
 // RunOptions are the per-run knobs, the same shape internal/applyform's RunOptions takes.
@@ -309,7 +316,7 @@ func (rn *run) failCaptcha(ctx context.Context, c Claimed, boardSaid string) out
 	if boardSaid != "" {
 		reason = fmt.Sprintf("%s: %s", reason, boardSaid)
 	}
-	dead, failErr := rn.store.Fail(ctx, c.QueueID, reason, captchaMaxAttempts)
+	dead, failErr := rn.store.FailCaptcha(ctx, c.QueueID, reason, captchaMaxAttempts)
 	if failErr != nil {
 		log.Printf("auto-apply: record captcha refusal for queue entry %d: %v", c.QueueID, failErr)
 	} else if dead {

--- a/internal/application/autoapply/runner_captcha_counter_test.go
+++ b/internal/application/autoapply/runner_captcha_counter_test.go
@@ -1,0 +1,29 @@
+package autoapply
+
+import (
+	"context"
+	"testing"
+)
+
+// A captcha refusal counts on its OWN budget, through its own store call. Sharing the
+// ordinary one poisoned it: a live entry collected 12 captcha refusals and was then
+// dead-lettered by the first field fill that timed out, without the three tries that error
+// was entitled to. The same trap migration 0140 fixed for the preview pass.
+func TestRunSpendsACaptchaRefusalOnItsOwnCounter(t *testing.T) {
+	store := &fakeStore{waves: [][]Claimed{{{QueueID: 9, UserID: 10, JobID: 100}}}}
+	answers := &fakeAnswers{answers: map[string]string{}}
+	sidecar := &fakeSidecar{result: SidecarResult{Status: StatusCaptchaRefused}}
+
+	if _, err := Run(context.Background(), store, answers, sidecar, opts()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.failedCaptcha) != 1 || store.failedCaptcha[0] != 9 {
+		t.Errorf("Store.FailCaptcha calls = %v, want [9]", store.failedCaptcha)
+	}
+	if len(store.failed) != 0 {
+		t.Errorf("Store.Fail calls = %v, want none — a captcha refusal must not touch the ordinary attempts budget", store.failed)
+	}
+	if store.failCaptchaMax != captchaMaxAttempts {
+		t.Errorf("FailCaptcha called with maxAttempts=%d, want %d", store.failCaptchaMax, captchaMaxAttempts)
+	}
+}

--- a/internal/application/autoapply/runner_captcha_test.go
+++ b/internal/application/autoapply/runner_captcha_test.go
@@ -27,14 +27,14 @@ func TestRunRetriesACaptchaRefusalOnItsOwnGenerousBudget(t *testing.T) {
 	if stats.Failed != 1 {
 		t.Errorf("Failed = %d, want 1 — a captcha refusal is a failed attempt, just a retryable one", stats.Failed)
 	}
-	if len(store.failed) != 1 || store.failed[0] != 7 {
-		t.Fatalf("Store.Fail calls = %v, want [7]", store.failed)
+	if len(store.failedCaptcha) != 1 || store.failedCaptcha[0] != 7 {
+		t.Fatalf("Store.FailCaptcha calls = %v, want [7]", store.failedCaptcha)
 	}
-	if store.failMax != captchaMaxAttempts {
-		t.Errorf("Fail called with maxAttempts=%d, want captchaMaxAttempts=%d", store.failMax, captchaMaxAttempts)
+	if store.failCaptchaMax != captchaMaxAttempts {
+		t.Errorf("FailCaptcha called with maxAttempts=%d, want captchaMaxAttempts=%d", store.failCaptchaMax, captchaMaxAttempts)
 	}
-	if store.failMax <= opts().MaxAttempts {
-		t.Errorf("captchaMaxAttempts=%d is not more generous than the ordinary budget %d, which is the whole point", store.failMax, opts().MaxAttempts)
+	if store.failCaptchaMax <= opts().MaxAttempts {
+		t.Errorf("captchaMaxAttempts=%d is not more generous than the ordinary budget %d, which is the whole point", store.failCaptchaMax, opts().MaxAttempts)
 	}
 }
 

--- a/internal/application/autoapply/runner_test.go
+++ b/internal/application/autoapply/runner_test.go
@@ -17,11 +17,13 @@ type fakeStore struct {
 	parkedUnmapped map[int64][]UnmappedField
 	parkErr        error
 
-	failed       []int64
-	failAttempts map[int64]int
-	failMax      int
-	failMsg      string
-	failErr      error
+	failed         []int64
+	failAttempts   map[int64]int
+	failMax        int
+	failMsg        string
+	failedCaptcha  []int64
+	failCaptchaMax int
+	failErr        error
 }
 
 func (f *fakeStore) Claim(ctx context.Context, batch, leaseSeconds int) ([]Claimed, error) {
@@ -50,6 +52,20 @@ func (f *fakeStore) Park(ctx context.Context, queueID int64, unmapped []Unmapped
 	}
 	f.parkedUnmapped[queueID] = unmapped
 	return nil
+}
+
+func (f *fakeStore) FailCaptcha(ctx context.Context, queueID int64, errMsg string, maxAttempts int) (bool, error) {
+	if f.failErr != nil {
+		return false, f.failErr
+	}
+	f.failedCaptcha = append(f.failedCaptcha, queueID)
+	f.failCaptchaMax = maxAttempts
+	f.failMsg = errMsg
+	if f.failAttempts == nil {
+		f.failAttempts = map[int64]int{}
+	}
+	f.failAttempts[queueID]++
+	return f.failAttempts[queueID] >= maxAttempts, nil
 }
 
 func (f *fakeStore) Fail(ctx context.Context, queueID int64, errMsg string, maxAttempts int) (bool, error) {

--- a/internal/platform/db/auto_apply_queue.sql.go
+++ b/internal/platform/db/auto_apply_queue.sql.go
@@ -493,6 +493,48 @@ func (q *Queries) MarkAutoApplyTailorFailed(ctx context.Context, arg MarkAutoApp
 	return i, err
 }
 
+const recordAutoApplyCaptchaRefusal = `-- name: RecordAutoApplyCaptchaRefusal :one
+UPDATE auto_apply_queue
+SET captcha_attempts = captcha_attempts + 1,
+    last_error       = $1,
+    failed_at        = CASE
+                           WHEN captcha_attempts + 1 >= $2::int THEN now()
+                           ELSE NULL
+                       END
+WHERE id = $3
+RETURNING captcha_attempts, failed_at
+`
+
+type RecordAutoApplyCaptchaRefusalParams struct {
+	LastError   string `json:"last_error"`
+	MaxAttempts int32  `json:"max_attempts"`
+	ID          int64  `json:"id"`
+}
+
+type RecordAutoApplyCaptchaRefusalRow struct {
+	CaptchaAttempts int32              `json:"captcha_attempts"`
+	FailedAt        pgtype.Timestamptz `json:"failed_at"`
+}
+
+// RecordAutoApplyFailure's counterpart for the one refusal that is safe to retry, on its
+// own counter (migration 0157). A board that says it could not VERIFY the submission has
+// told us it created no application, so asking again costs the employer nothing — and it
+// must be asked many more times than an ordinary failure, because an invisible captcha is a
+// coin toss no browser configuration improves.
+//
+// Its own column for the same reason RecordAutoApplyPreviewFailure has one: counting these
+// asks in `attempts` spent down the budget the genuinely transient errors depend on, and a
+// live entry that had collected 12 captcha refusals was dead-lettered by the first field
+// fill that timed out, without the three tries that error was entitled to. Same shape
+// otherwise: bump the counter, record the reason, dead-letter once it reaches the max,
+// leave the lease in place.
+func (q *Queries) RecordAutoApplyCaptchaRefusal(ctx context.Context, arg RecordAutoApplyCaptchaRefusalParams) (RecordAutoApplyCaptchaRefusalRow, error) {
+	row := q.db.QueryRow(ctx, recordAutoApplyCaptchaRefusal, arg.LastError, arg.MaxAttempts, arg.ID)
+	var i RecordAutoApplyCaptchaRefusalRow
+	err := row.Scan(&i.CaptchaAttempts, &i.FailedAt)
+	return i, err
+}
+
 const recordAutoApplyFailure = `-- name: RecordAutoApplyFailure :one
 UPDATE auto_apply_queue
 SET attempts   = attempts + 1,

--- a/internal/platform/db/models.go
+++ b/internal/platform/db/models.go
@@ -189,6 +189,7 @@ type AutoApplyQueue struct {
 	PreviewAttempts int32              `json:"preview_attempts"`
 	PreviewFailedAt pgtype.Timestamptz `json:"preview_failed_at"`
 	TailorFailedAt  pgtype.Timestamptz `json:"tailor_failed_at"`
+	CaptchaAttempts int32              `json:"captcha_attempts"`
 }
 
 type BillingEvent struct {

--- a/internal/platform/db/querier.go
+++ b/internal/platform/db/querier.go
@@ -4658,6 +4658,19 @@ type Querier interface {
 	// place — its expiry gates the retry to a later run and doubles as the crash reaper, so a
 	// failed entry is never reprocessed within the same run. Mirrors RecordSemanticFailure.
 	RecordApplyFormFailure(ctx context.Context, arg RecordApplyFormFailureParams) (RecordApplyFormFailureRow, error)
+	// RecordAutoApplyFailure's counterpart for the one refusal that is safe to retry, on its
+	// own counter (migration 0157). A board that says it could not VERIFY the submission has
+	// told us it created no application, so asking again costs the employer nothing — and it
+	// must be asked many more times than an ordinary failure, because an invisible captcha is a
+	// coin toss no browser configuration improves.
+	//
+	// Its own column for the same reason RecordAutoApplyPreviewFailure has one: counting these
+	// asks in `attempts` spent down the budget the genuinely transient errors depend on, and a
+	// live entry that had collected 12 captcha refusals was dead-lettered by the first field
+	// fill that timed out, without the three tries that error was entitled to. Same shape
+	// otherwise: bump the counter, record the reason, dead-letter once it reaches the max,
+	// leave the lease in place.
+	RecordAutoApplyCaptchaRefusal(ctx context.Context, arg RecordAutoApplyCaptchaRefusalParams) (RecordAutoApplyCaptchaRefusalRow, error)
 	// Count a transient failure: bump attempts, record the error, and dead-letter (set
 	// failed_at) once attempts reach the max. The lease (claimed_at) is intentionally left in
 	// place — its expiry gates the retry to a later run, so a failed entry is never

--- a/internal/platform/db/queries/auto_apply_queue.sql
+++ b/internal/platform/db/queries/auto_apply_queue.sql
@@ -125,6 +125,29 @@ SET preview_attempts = preview_attempts + 1,
 WHERE id = sqlc.arg(id)
 RETURNING preview_attempts, preview_failed_at;
 
+-- name: RecordAutoApplyCaptchaRefusal :one
+-- RecordAutoApplyFailure's counterpart for the one refusal that is safe to retry, on its
+-- own counter (migration 0157). A board that says it could not VERIFY the submission has
+-- told us it created no application, so asking again costs the employer nothing — and it
+-- must be asked many more times than an ordinary failure, because an invisible captcha is a
+-- coin toss no browser configuration improves.
+--
+-- Its own column for the same reason RecordAutoApplyPreviewFailure has one: counting these
+-- asks in `attempts` spent down the budget the genuinely transient errors depend on, and a
+-- live entry that had collected 12 captcha refusals was dead-lettered by the first field
+-- fill that timed out, without the three tries that error was entitled to. Same shape
+-- otherwise: bump the counter, record the reason, dead-letter once it reaches the max,
+-- leave the lease in place.
+UPDATE auto_apply_queue
+SET captcha_attempts = captcha_attempts + 1,
+    last_error       = sqlc.arg(last_error),
+    failed_at        = CASE
+                           WHEN captcha_attempts + 1 >= sqlc.arg(max_attempts)::int THEN now()
+                           ELSE NULL
+                       END
+WHERE id = sqlc.arg(id)
+RETURNING captcha_attempts, failed_at;
+
 -- name: MarkAutoApplyTailorFailed :one
 -- Records that a tailoring run gave up without producing a CV (migration 0154), so the
 -- entry stops reading as one still being prepared.

--- a/migrations/0157_auto_apply_queue_captcha_attempts.sql
+++ b/migrations/0157_auto_apply_queue_captcha_attempts.sql
@@ -1,0 +1,18 @@
+-- Give a captcha refusal its own attempt counter.
+--
+-- A captcha refusal is the one post-submit outcome safe to retry, and it needs many more
+-- tries than an ordinary failure: an invisible hCaptcha is a coin toss no browser
+-- configuration improves (measured 2026-09-10 over eight probe runs against a live Lever
+-- posting — headless and windowed under Xvfb, datacentre and residential IP, with and
+-- without warm-up: one pass). Counting those asks in `attempts` poisoned the ordinary
+-- budget: a live entry reached 12 captcha refusals, and then the first genuinely transient
+-- error — a field fill timing out — dead-lettered it instantly, without the three tries
+-- that error was entitled to.
+--
+-- Same remedy migration 0140 already applied to the preview pass, for the same reason.
+-- A bounded retry counter capped at 20 by the code that writes it, matching the integer
+-- `attempts` and `preview_attempts` beside it — a bigint here would only make the three
+-- columns disagree about the same kind of number.
+ALTER TABLE auto_apply_queue
+    -- squawk-ignore prefer-bigint-over-int
+    ADD COLUMN captcha_attempts integer NOT NULL DEFAULT 0;


### PR DESCRIPTION
Retrying a captcha refusal 20 times shared one column with the ordinary 3-attempt budget, so the generous budget spent down the strict one.

A live Lever entry proved it within the hour: after 12 captcha refusals the first genuinely transient error — `fill "phone": context deadline exceeded` — dead-lettered it instantly, without the three tries that error was entitled to.

`captcha_attempts` (migration 0157) separates them, exactly as migration 0140 separated the preview pass for the same reason and with the same argument. `failed_at` stays shared: running out of asks is still the entry giving up, and the candidate hears about it the same way.

Tests cover both directions — a captcha refusal spends only the new counter, and never touches `Store.Fail`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Captcha refusals now use a separate retry budget from other transient auto-apply failures.
  - Repeated captcha refusals no longer consume retries reserved for other recoverable errors.
  - Captcha failures are still moved to the dead-letter state once their dedicated retry limit is reached.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->