### PR TITLE
Count a fill that times out under a captcha challenge as the captcha

### DIFF
--- a/internal/api/atsapply/fill.go
+++ b/internal/api/atsapply/fill.go
@@ -83,6 +83,45 @@ type captchaRefusal struct{ detail error }
 func (e captchaRefusal) Error() string   { return e.detail.Error() }
 func (e captchaRefusal) Unwrap() []error { return []error{errCaptchaRefused, e.detail} }
 
+// challengeVisibleJS asks the page whether a captcha challenge is actually ON SCREEN. Both
+// conditions are load-bearing and both were learned the same way, by reading a live page:
+// the provider mounts its frames on EVERY posting at full size and keeps them
+// visibility:hidden until it poses a puzzle, so size alone says nothing — an earlier version
+// of this check called a hidden frame a challenge and reported a run that had actually
+// PASSED as refused.
+const challengeVisibleJS = `(() => Array.from(document.querySelectorAll("iframe")).some(f => {
+	const src = f.src || "";
+	if (!src.includes("hcaptcha.com") && !src.includes("recaptcha")) return false;
+	if (window.getComputedStyle(f).visibility === "hidden") return false;
+	return f.getBoundingClientRect().height > 100;
+}))()`
+
+// challengeVisible reports whether a captcha challenge currently covers the form. A page that
+// cannot be asked (the browser is gone, the context is done) answers false: this only ever
+// reclassifies a failure that already happened, and guessing "captcha" without evidence would
+// hand an ordinary error the captcha's twenty asks.
+func challengeVisible(ctx context.Context) bool {
+	var visible bool
+	if err := chromedp.Run(ctx, chromedp.Evaluate(challengeVisibleJS, &visible)); err != nil {
+		return false
+	}
+	return visible
+}
+
+// classifyFillFailure decides whether a failure to fill a field was really the captcha.
+//
+// Lever's own page binds the invisible captcha to the LOCATION field's focus — touching it
+// calls hcaptcha.execute() — so when the score is not enough the challenge covers the form
+// and the very next keystroke times out. Recorded as an ordinary transient error, three of
+// those dead-lettered a live entry whose captcha budget still had twelve asks left. The
+// cause is the captcha, so it belongs on the captcha's counter.
+func classifyFillFailure(err error, challengeOnScreen bool) error {
+	if challengeOnScreen {
+		return captchaRefusal{detail: err}
+	}
+	return err
+}
+
 // newRefusalError builds the error a matched refusal marker travels as: the marker that
 // fired, the board's own sentence around it, and — when the board declined to verify — the
 // errCaptchaRefused sentinel the runner reads with errors.Is.
@@ -125,7 +164,7 @@ func refusalEvidence(bodyText, marker string) string {
 func fillAndSubmit(ctx context.Context, plan Plan, layout formLayout) (bool, error) {
 	for _, f := range plan.Fields {
 		if err := fillOne(ctx, f, layout.addressBy); err != nil {
-			return false, fmt.Errorf("fill %q: %w", f.ID, err)
+			return false, classifyFillFailure(fmt.Errorf("fill %q: %w", f.ID, err), challengeVisible(ctx))
 		}
 	}
 

--- a/internal/api/atsapply/fill_challenge_test.go
+++ b/internal/api/atsapply/fill_challenge_test.go
@@ -1,0 +1,44 @@
+package atsapply
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// Lever's own page binds the invisible captcha to the LOCATION field's focus: touching it
+// calls hcaptcha.execute(), and when the score is not enough the challenge covers the form.
+// Typing into a covered field then times out — a failure caused by the captcha, recorded as
+// an ordinary transient error. Three of those spent the strict budget and dead-lettered a
+// live entry whose captcha budget still had 12 asks left.
+func TestFillFailure_UnderAVisibleChallengeIsACaptchaRefusal(t *testing.T) {
+	cause := fmt.Errorf("fill %q: %w", "location", errors.New("context deadline exceeded"))
+
+	err := classifyFillFailure(cause, true)
+
+	if !errors.Is(err, errCaptchaRefused) {
+		t.Fatalf("err = %v, want it to wrap errCaptchaRefused", err)
+	}
+	if !contains(err.Error(), "location") {
+		t.Errorf("err = %v, want it to still name the field that failed", err)
+	}
+}
+
+// With no challenge on screen the same timeout is what it looks like: a slow page, which is
+// exactly what the ordinary three-attempt budget is for.
+func TestFillFailure_WithoutAChallengeStaysOrdinary(t *testing.T) {
+	cause := fmt.Errorf("fill %q: %w", "phone", errors.New("context deadline exceeded"))
+
+	if err := classifyFillFailure(cause, false); errors.Is(err, errCaptchaRefused) {
+		t.Errorf("err = %v, want an ordinary failure", err)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Lever's own page binds the invisible captcha to the **location field's focus** — touching it calls `hcaptcha.execute()` — so when the score is not enough the challenge covers the form and the next keystroke times out.

Recorded as an ordinary transient error, three of those dead-lettered a live entry whose captcha budget still had **twelve asks left**: the strict budget spent on exactly the failure the generous one exists for. Observed tonight as `fill "location": context deadline exceeded` and `fill "phone": context deadline exceeded`.

`classifyFillFailure` asks the page whether a challenge is actually on screen and routes the failure to the captcha's counter if it is.

The on-screen check tests **visibility as well as size**, both learned from a live page: the provider mounts full-size frames on every posting and keeps them `visibility:hidden` until it poses a puzzle. Size alone reported a probe run that had actually *passed* as refused earlier today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application submission error handling when a CAPTCHA challenge appears during form completion.
  * CAPTCHA-related failures are now identified more accurately while preserving the affected field’s details.
* **Tests**
  * Added coverage for distinguishing CAPTCHA refusals from ordinary field-fill timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->