### PR TITLE
Send Lever to the cloud agent, which solves the captcha itself

### DIFF
--- a/internal/api/atsapply/browseruse_fill.go
+++ b/internal/api/atsapply/browseruse_fill.go
@@ -33,6 +33,32 @@ import (
 var browserUseProviders = map[string]bool{
 	"ashby":    true,
 	"workable": true,
+	// Lever is here for a different reason than the other two: it HAS a working fill
+	// path, and that path mostly cannot finish. Its forms carry an invisible hCaptcha —
+	// 10 of 12 live postings sampled on 2026-09-10 — and this package's own Chrome
+	// passes it about one attempt in eight. Eight probe runs (headless and windowed
+	// under Xvfb, datacentre and residential IP, with and without mouse/scroll warm-up,
+	// with and without a User-Agent naming HeadlessChrome) moved the odds not at all;
+	// the pass looked like a coin landing well. The cloud agent runs a hardened browser
+	// behind residential proxies and solves supported captchas itself, with no request
+	// field to turn that on. So Lever is routed here deliberately, at a cost per
+	// attempt, rather than left on a free path that mostly parks.
+	"lever": true,
+}
+
+// agentTargetURL is the page the cloud agent is told to open for a posting.
+//
+// Not simply the posting URL: Lever renders its description and its form on two pages, and
+// the form is at the posting URL plus /apply. The Chrome path already learned this the
+// expensive way — a live attempt parked as unrecognized_form_layout on a page that loaded
+// fine and had no form on it — and layout.go holds that knowledge. Handing the agent the
+// same wrong URL would repeat that, only slower and for money.
+func agentTargetURL(provider, postingURL string) string {
+	layout, ok := layoutFor(provider)
+	if !ok {
+		return postingURL
+	}
+	return layout.applyURL(postingURL)
 }
 
 // browserUseOutcome is the terminal signal buildTask's own instruction requires the

--- a/internal/api/atsapply/browseruse_fill_test.go
+++ b/internal/api/atsapply/browseruse_fill_test.go
@@ -194,7 +194,11 @@ func TestBrowserUseEligible(t *testing.T) {
 		{"ashby with no file field", "ashby", Plan{Fields: []ResolvedField{{ID: "email", Kind: "text"}}}, true},
 		{"workable with no file field", "workable", Plan{}, true},
 		{"greenhouse is never eligible", "greenhouse", Plan{}, false},
-		{"unknown provider is never eligible", "lever", Plan{}, false},
+		// Lever moved here on 2026-09-10: it has a working fill path that loses the
+		// invisible-hCaptcha coin toss seven attempts in eight, and the cloud browser
+		// solves supported captchas itself. See browserUseProviders.
+		{"lever, whose own fill path the captcha mostly blocks", "lever", Plan{}, true},
+		{"unknown provider is never eligible", "smartrecruiters", Plan{}, false},
 		// Recruitee has no registered applyform.Fetcher at all (found during
 		// implementation — see browserUseProviders' own doc comment), so Client.Submit
 		// never even reaches browserUseEligible for it; excluded here for the same reason.

--- a/internal/api/atsapply/client.go
+++ b/internal/api/atsapply/client.go
@@ -53,11 +53,6 @@ const tagAutoApplyDrafting = "auto-apply-drafting"
 // reach a submit click with selectors matching nothing.
 var fillProviders = map[string]bool{
 	"greenhouse": true,
-	// Measured 2026-09-09. Retiring the blanket captcha refusal (#2721) let the preview
-	// pass reach Lever's schema for the first time, and it came back with every field
-	// answered and nothing pending; the form's controls were captured from a live posting
-	// the same day (see leverform_test.go's fixture).
-	"lever": true,
 }
 
 // reasonSubmissionNotImplemented is the one park reason for two distinct gaps that both
@@ -250,7 +245,7 @@ func (c *Client) Submit(ctx context.Context, claimed autoapply.Claimed, answers 
 			}
 			if !browserUseEnforce() {
 				log.Printf("atsapply: browser-use fallback would attempt job %d (%s) — shadow mode, still parking", claimed.JobID, claimed.Provider)
-			} else if result, handled, err := c.browserUse.submit(ctx, plan, merged, claimed.JobURL); handled {
+			} else if result, handled, err := c.browserUse.submit(ctx, plan, merged, agentTargetURL(claimed.Provider, claimed.JobURL)); handled {
 				return result, err
 			}
 		}

--- a/internal/api/atsapply/fill.go
+++ b/internal/api/atsapply/fill.go
@@ -83,6 +83,45 @@ type captchaRefusal struct{ detail error }
 func (e captchaRefusal) Error() string   { return e.detail.Error() }
 func (e captchaRefusal) Unwrap() []error { return []error{errCaptchaRefused, e.detail} }
 
+// challengeVisibleJS asks the page whether a captcha challenge is actually ON SCREEN. Both
+// conditions are load-bearing and both were learned the same way, by reading a live page:
+// the provider mounts its frames on EVERY posting at full size and keeps them
+// visibility:hidden until it poses a puzzle, so size alone says nothing — an earlier version
+// of this check called a hidden frame a challenge and reported a run that had actually
+// PASSED as refused.
+const challengeVisibleJS = `(() => Array.from(document.querySelectorAll("iframe")).some(f => {
+	const src = f.src || "";
+	if (!src.includes("hcaptcha.com") && !src.includes("recaptcha")) return false;
+	if (window.getComputedStyle(f).visibility === "hidden") return false;
+	return f.getBoundingClientRect().height > 100;
+}))()`
+
+// challengeVisible reports whether a captcha challenge currently covers the form. A page that
+// cannot be asked (the browser is gone, the context is done) answers false: this only ever
+// reclassifies a failure that already happened, and guessing "captcha" without evidence would
+// hand an ordinary error the captcha's twenty asks.
+func challengeVisible(ctx context.Context) bool {
+	var visible bool
+	if err := chromedp.Run(ctx, chromedp.Evaluate(challengeVisibleJS, &visible)); err != nil {
+		return false
+	}
+	return visible
+}
+
+// classifyFillFailure decides whether a failure to fill a field was really the captcha.
+//
+// Lever's own page binds the invisible captcha to the LOCATION field's focus — touching it
+// calls hcaptcha.execute() — so when the score is not enough the challenge covers the form
+// and the very next keystroke times out. Recorded as an ordinary transient error, three of
+// those dead-lettered a live entry whose captcha budget still had twelve asks left. The
+// cause is the captcha, so it belongs on the captcha's counter.
+func classifyFillFailure(err error, challengeOnScreen bool) error {
+	if challengeOnScreen {
+		return captchaRefusal{detail: err}
+	}
+	return err
+}
+
 // newRefusalError builds the error a matched refusal marker travels as: the marker that
 // fired, the board's own sentence around it, and — when the board declined to verify — the
 // errCaptchaRefused sentinel the runner reads with errors.Is.
@@ -125,7 +164,7 @@ func refusalEvidence(bodyText, marker string) string {
 func fillAndSubmit(ctx context.Context, plan Plan, layout formLayout) (bool, error) {
 	for _, f := range plan.Fields {
 		if err := fillOne(ctx, f, layout.addressBy); err != nil {
-			return false, fmt.Errorf("fill %q: %w", f.ID, err)
+			return false, classifyFillFailure(fmt.Errorf("fill %q: %w", f.ID, err), challengeVisible(ctx))
 		}
 	}
 

--- a/internal/api/atsapply/fill_challenge_test.go
+++ b/internal/api/atsapply/fill_challenge_test.go
@@ -1,0 +1,44 @@
+package atsapply
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// Lever's own page binds the invisible captcha to the LOCATION field's focus: touching it
+// calls hcaptcha.execute(), and when the score is not enough the challenge covers the form.
+// Typing into a covered field then times out — a failure caused by the captcha, recorded as
+// an ordinary transient error. Three of those spent the strict budget and dead-lettered a
+// live entry whose captcha budget still had 12 asks left.
+func TestFillFailure_UnderAVisibleChallengeIsACaptchaRefusal(t *testing.T) {
+	cause := fmt.Errorf("fill %q: %w", "location", errors.New("context deadline exceeded"))
+
+	err := classifyFillFailure(cause, true)
+
+	if !errors.Is(err, errCaptchaRefused) {
+		t.Fatalf("err = %v, want it to wrap errCaptchaRefused", err)
+	}
+	if !contains(err.Error(), "location") {
+		t.Errorf("err = %v, want it to still name the field that failed", err)
+	}
+}
+
+// With no challenge on screen the same timeout is what it looks like: a slow page, which is
+// exactly what the ordinary three-attempt budget is for.
+func TestFillFailure_WithoutAChallengeStaysOrdinary(t *testing.T) {
+	cause := fmt.Errorf("fill %q: %w", "phone", errors.New("context deadline exceeded"))
+
+	if err := classifyFillFailure(cause, false); errors.Is(err, errCaptchaRefused) {
+		t.Errorf("err = %v, want an ordinary failure", err)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/atsapply/layout_test.go
+++ b/internal/api/atsapply/layout_test.go
@@ -88,12 +88,18 @@ func TestAddressing_QueryKindMatchesTheSelectorItProduces(t *testing.T) {
 	}
 }
 
-// Lever can be filled. This is the switch the whole change exists to flip, and it is
-// asserted separately from the layout because the two live in different files — which is
-// exactly what TestLayoutFor_CoversEveryFillProvider guards from the other side.
-func TestFillProviders_IncludesLever(t *testing.T) {
-	if !fillProviders["lever"] {
-		t.Error("lever is not in fillProviders; its resolved plans still park as not-implemented")
+// Lever keeps its layout without being a fill provider, and that is not an oversight. The
+// layout's applyPath is what tells ANY executor which page the form is on, and the cloud
+// agent that now submits Lever reads it through agentTargetURL. The submit selector and
+// addressing beside it are dormant rather than dead — they are what a Lever fill path would
+// need again if the captcha ever stopped deciding these attempts.
+func TestLeverKeepsItsLayoutAfterMovingToTheCloudAgent(t *testing.T) {
+	layout, ok := layoutFor("lever")
+	if !ok {
+		t.Fatal("lever lost its layout, so nothing knows its form is at /apply")
+	}
+	if layout.applyPath != "/apply" {
+		t.Errorf("lever applyPath = %q, want /apply", layout.applyPath)
 	}
 }
 

--- a/internal/api/atsapply/lever_via_browseruse_test.go
+++ b/internal/api/atsapply/lever_via_browseruse_test.go
@@ -1,0 +1,40 @@
+package atsapply
+
+import "testing"
+
+// Lever's forms carry an invisible hCaptcha — measured 2026-09-10 on 10 of 12 live
+// postings — and this package's own headless Chrome passes it about one attempt in eight,
+// with nothing about the browser moving the odds. The cloud agent runs a hardened browser
+// behind residential proxies and solves supported captchas itself, so Lever goes there
+// instead of down a fill path that mostly cannot finish.
+func TestLeverGoesThroughTheCloudAgent(t *testing.T) {
+	if fillProviders["lever"] {
+		t.Error("lever is still a fill provider; its own Chrome loses the captcha coin toss seven times in eight")
+	}
+	if !browserUseProviders["lever"] {
+		t.Error("lever is not routed to the cloud agent, so it would park instead of being submitted")
+	}
+}
+
+// The agent is told which page to open, and for Lever that is not the posting URL: the
+// posting carries the description and no form at all. A live attempt already parked as
+// unrecognized_form_layout for exactly that reason on the Chrome path — handing the same
+// wrong URL to the agent would repeat it, only slower and for money.
+func TestCloudAgentIsSentTheFormsOwnPage(t *testing.T) {
+	posting := "https://jobs.lever.co/acme/abc-123"
+
+	got := agentTargetURL("lever", posting)
+
+	if want := posting + "/apply"; got != want {
+		t.Errorf("agentTargetURL = %q, want %q", got, want)
+	}
+}
+
+// A provider whose posting URL IS the form page is handed it unchanged.
+func TestCloudAgentTargetIsUnchangedWhereTheFormLivesOnThePosting(t *testing.T) {
+	posting := "https://jobs.ashbyhq.com/acme/abc-123"
+
+	if got := agentTargetURL("ashby", posting); got != posting {
+		t.Errorf("agentTargetURL = %q, want it unchanged", got)
+	}
+}


### PR DESCRIPTION
Lever has a working fill path that mostly cannot finish.

Its forms carry an invisible hCaptcha — **10 of 12** live postings sampled 2026-09-10 — and our own Chrome passes it about **one attempt in eight**. Eight probe runs moved the odds not at all:

| Where | Mode | Result |
|---|---|---|
| Residential IP | windowed + warm-up | passed |
| Residential IP | windowed + warm-up (repeat) | challenged |
| Residential IP | windowed, no warm-up | challenged |
| Residential IP | headless | challenged |
| Hetzner | headless | challenged |
| Hetzner | windowed (Xvfb) | challenged |
| Hetzner | windowed + warm-up | challenged |
| Hetzner | headless, honest User-Agent | challenged |

Browser Use's cloud browsers run hardened, behind residential proxies, and per their docs *"enable automatic CAPTCHA solving… There is no request field to turn on."* So Lever moves there deliberately, at a cost per attempt, rather than staying on a free path that mostly parks. The existing `AUTO_APPLY_BROWSERUSE_RUN_CAP_USD` guard still bounds a run.

**`agentTargetURL`** tells the agent which page to open, reading the layout's `applyPath`. Lever's posting URL carries the description and no form — handing the agent that URL would repeat the `unrecognized_form_layout` a live attempt already hit on the Chrome path, only slower and for money.

Lever keeps its layout: `applyPath` is what any executor needs, and the fill selectors beside it are dormant, not dead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application handling for Lever postings by routing submissions through the appropriate application experience.
  * Captcha-related fill failures are now detected and retried more accurately.
  * Application requests now target the form’s direct page when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->