### PR TITLE
Fix pricing page grid when Ultra isn't offered

### DIFF
--- a/web/src/routes/pricing/+page.svelte
+++ b/web/src/routes/pricing/+page.svelte
@@ -227,7 +227,10 @@
   </p>
 {/snippet}
 
-<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+<!-- Three tracks only when there is a third card to fill one: a grid fixed at
+     lg:grid-cols-3 with two children leaves the third an empty gap on wide screens instead
+     of the two cards sharing the row the way they already do at the sm breakpoint. -->
+<div class="grid gap-4 sm:grid-cols-2 {ultraChosen ? 'lg:grid-cols-3' : ''}">
     <!-- Free -->
     <section class="flex flex-col gap-4 rounded-xl border border-border p-6">
       <div class="flex flex-col gap-1">


### PR DESCRIPTION
## Summary
- \`/pricing\`'s grid was fixed at \`lg:grid-cols-3\` regardless of how many plan cards actually render. With Ultra pulled from sale (see #2754) there are only two cards (Free, Pro), and the fixed third column left an empty gap on wide screens instead of the two cards sharing the row — the same 2-column behavior the grid already uses at the \`sm\` breakpoint.
- Fix: the third column only applies when \`ultraChosen\` is truthy (i.e. Ultra actually has a price to show), matching the existing pattern elsewhere in this codebase for conditional Tailwind classes.

## Test plan
- [x] \`pnpm check\` (svelte-check) — 0 errors
- [x] \`eslint\` on the touched file — clean
- [x] \`pnpm build\` — succeeds
- [ ] Will screenshot the live page after this deploys to confirm visually (reported by the user as looking wrong on production before this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the pricing page layout so plan cards no longer leave an empty gap on wide screens when fewer than three plans are available.
  - The three-column layout now appears only when all three plan options are shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->