### PR TITLE
Offer an upgrade where a free-tier allowance refusal is shown

### DIFF
--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -3,7 +3,7 @@
   "Avatar": 2,
   "Badge": 25,
   "BrandMark": 2,
-  "Button": 81,
+  "Button": 82,
   "Card": 14,
   "Chip": 7,
   "ConfirmDialog": 17,

--- a/web/src/lib/components/MatchAnalysisFull.svelte
+++ b/web/src/lib/components/MatchAnalysisFull.svelte
@@ -373,11 +373,15 @@
          recompute of an already-analysed role stays available on those pages). While the
          ceiling is only being counted this stays hidden and the analysis runs. -->
     {#if blockedNew}
-      <div class="fit-reveal flex flex-col items-center gap-2 rounded-xl border border-dashed border-border bg-card p-10 text-center" style="--i:1">
+      <!-- refuses() never trips for an unlimited allowance, and pro/ultra never report one
+           that isn't — so reaching this branch already means free tier, and the upgrade
+           offer is never a guess. -->
+      <div class="fit-reveal flex flex-col items-center gap-3 rounded-xl border border-dashed border-border bg-card p-10 text-center" style="--i:1">
         <p class="text-sm font-medium">You've used today's job analyses.</p>
         <p class="text-xs text-muted-foreground">
           More at {resetsAtLabel(allowance)}. Analyses you've already run stay available.
         </p>
+        <Button variant="primary" size="sm" href={resolve('/pricing')}>Upgrade</Button>
       </div>
     {/if}
 

--- a/web/src/lib/components/MatchSummary.svelte
+++ b/web/src/lib/components/MatchSummary.svelte
@@ -106,9 +106,15 @@
       </span>
     </a>
   {:else if allowanceRefused}
-    <p class="text-sm text-muted-foreground">
-      You've used today's {refusedName}. More at {resetsAtLabel(refusedAllowance)}.
-    </p>
+    <!-- This branch is reachable only on the free tier: `refuses` never trips for an
+         unlimited allowance, and pro/ultra never report one that isn't. So the upgrade CTA
+         is always the right offer here, not a guess at who is looking at it. -->
+    <div class="flex items-center justify-between gap-2">
+      <span class="text-sm text-muted-foreground">
+        You've used today's {refusedName}. More at {resetsAtLabel(refusedAllowance)}.
+      </span>
+      <Button variant="primary" size="sm" href={resolve('/pricing')}>Upgrade</Button>
+    </div>
   {:else}
     <Button
       variant="primary"

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -27,7 +27,7 @@
   import StyleSettings from '$lib/components/cv/StyleSettings.svelte';
   import TemplateGallery from '$lib/tailor/TemplateGallery.svelte';
   import AccountNavRail from '$lib/components/AccountNavRail.svelte';
-  import { ConfirmDialog } from '$lib/ui';
+  import { Button, ConfirmDialog } from '$lib/ui';
   import { clampWidth } from '$lib/tailor/geometry';
   import { undoRun, openingActions } from '$lib/tailor/autopilot';
   import {
@@ -47,6 +47,10 @@
 
   let status = $state<'loading' | 'ready' | 'error'>('loading');
   let errorMsg = $state('');
+  // Read off the 402 body rather than inferred from the status code: the server omits it
+  // for a fair-use refusal and for a caller already on the top tier, and duplicating that
+  // rule here would drift from it the next time a tier is added.
+  let upgradeUrl = $state<string | null>(null);
   let sessionId = $state<string | undefined>(undefined);
   let resuming = $state(false);
   let cvId = $state('');
@@ -310,8 +314,11 @@
           ? ` More at ${new Date(resetsAt).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}.`
           : '';
         errorMsg = `${e.message}${more}`;
+        const url = e.body?.upgrade_url;
+        upgradeUrl = typeof url === 'string' ? url : null;
       } else {
         errorMsg = e instanceof ApiError ? e.message : 'Could not open the tailoring workspace.';
+        upgradeUrl = null;
       }
       status = 'error';
     }
@@ -529,6 +536,9 @@
   {:else if status === 'error'}
     <div class="flex min-w-0 flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
       <p class="max-w-md text-sm text-destructive">{errorMsg}</p>
+      {#if upgradeUrl}
+        <Button variant="primary" size="sm" href={upgradeUrl}>Upgrade</Button>
+      {/if}
       <a href={resolve('/jobs/[slug]', { slug })} class="text-sm text-brand hover:underline">Back to the role</a>
     </div>
   {:else}


### PR DESCRIPTION
## Summary
Three surfaces told a free account its CV tailorings or job analyses were spent for the day with no way forward: the job-page match summary widget (`MatchSummary.svelte`), the full-page fit analysis (`MatchAnalysisFull.svelte`), and the tailoring workspace's own bootstrap error (`routes/tailor/[slug]/+page.svelte`). Now that free carries a zero allowance for these features (#2754), that refusal is the first thing most free users see, not a rare edge case after using up a couple of daily sessions — surfaced by a user hitting exactly this on production.

- `MatchSummary`/`MatchAnalysisFull`: reach their refused branch only through `refuses()`, which never trips for an unlimited allowance — pro/ultra never report one that isn't unlimited, so the branch is free-tier only and the "Upgrade" CTA is never a guess.
- The tailoring workspace: reads the 402 body's own `upgrade_url` instead, since that field already encodes the same rule server-side (`refuse`/`refuseStanding` in `plan_view.go` — omitted for a fair-use refusal or a caller already on the top tier) and duplicating it client-side would drift the next time a tier is added.

## Test plan
- [x] `pnpm check` (svelte-check) — 0 errors
- [x] `eslint` on the three touched files — clean
- [ ] Will verify visually against the live account that hit this after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added prominent Upgrade buttons to blocked match analysis and daily allowance messages.
  * Added a vertical upgrade prompt layout with improved spacing and a link to pricing.
  * Added an Upgrade button to tailored-page error messages when an upgrade link is available.
  * Upgrade options now direct eligible users to relevant pricing information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->