### PR TITLE
Revert: drop the free-tier Upgrade CTAs (Stripe is still test mode)

### DIFF
--- a/design-system/scripts/adoption-baseline.json
+++ b/design-system/scripts/adoption-baseline.json
@@ -3,7 +3,7 @@
   "Avatar": 2,
   "Badge": 25,
   "BrandMark": 2,
-  "Button": 82,
+  "Button": 81,
   "Card": 14,
   "Chip": 7,
   "ConfirmDialog": 17,

--- a/web/src/lib/components/MatchAnalysisFull.svelte
+++ b/web/src/lib/components/MatchAnalysisFull.svelte
@@ -373,15 +373,11 @@
          recompute of an already-analysed role stays available on those pages). While the
          ceiling is only being counted this stays hidden and the analysis runs. -->
     {#if blockedNew}
-      <!-- refuses() never trips for an unlimited allowance, and pro/ultra never report one
-           that isn't — so reaching this branch already means free tier, and the upgrade
-           offer is never a guess. -->
-      <div class="fit-reveal flex flex-col items-center gap-3 rounded-xl border border-dashed border-border bg-card p-10 text-center" style="--i:1">
+      <div class="fit-reveal flex flex-col items-center gap-2 rounded-xl border border-dashed border-border bg-card p-10 text-center" style="--i:1">
         <p class="text-sm font-medium">You've used today's job analyses.</p>
         <p class="text-xs text-muted-foreground">
           More at {resetsAtLabel(allowance)}. Analyses you've already run stay available.
         </p>
-        <Button variant="primary" size="sm" href={resolve('/pricing')}>Upgrade</Button>
       </div>
     {/if}
 

--- a/web/src/lib/components/MatchSummary.svelte
+++ b/web/src/lib/components/MatchSummary.svelte
@@ -106,15 +106,9 @@
       </span>
     </a>
   {:else if allowanceRefused}
-    <!-- This branch is reachable only on the free tier: `refuses` never trips for an
-         unlimited allowance, and pro/ultra never report one that isn't. So the upgrade CTA
-         is always the right offer here, not a guess at who is looking at it. -->
-    <div class="flex items-center justify-between gap-2">
-      <span class="text-sm text-muted-foreground">
-        You've used today's {refusedName}. More at {resetsAtLabel(refusedAllowance)}.
-      </span>
-      <Button variant="primary" size="sm" href={resolve('/pricing')}>Upgrade</Button>
-    </div>
+    <p class="text-sm text-muted-foreground">
+      You've used today's {refusedName}. More at {resetsAtLabel(refusedAllowance)}.
+    </p>
   {:else}
     <Button
       variant="primary"

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -27,7 +27,7 @@
   import StyleSettings from '$lib/components/cv/StyleSettings.svelte';
   import TemplateGallery from '$lib/tailor/TemplateGallery.svelte';
   import AccountNavRail from '$lib/components/AccountNavRail.svelte';
-  import { Button, ConfirmDialog } from '$lib/ui';
+  import { ConfirmDialog } from '$lib/ui';
   import { clampWidth } from '$lib/tailor/geometry';
   import { undoRun, openingActions } from '$lib/tailor/autopilot';
   import {
@@ -47,10 +47,6 @@
 
   let status = $state<'loading' | 'ready' | 'error'>('loading');
   let errorMsg = $state('');
-  // Read off the 402 body rather than inferred from the status code: the server omits it
-  // for a fair-use refusal and for a caller already on the top tier, and duplicating that
-  // rule here would drift from it the next time a tier is added.
-  let upgradeUrl = $state<string | null>(null);
   let sessionId = $state<string | undefined>(undefined);
   let resuming = $state(false);
   let cvId = $state('');
@@ -314,11 +310,8 @@
           ? ` More at ${new Date(resetsAt).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}.`
           : '';
         errorMsg = `${e.message}${more}`;
-        const url = e.body?.upgrade_url;
-        upgradeUrl = typeof url === 'string' ? url : null;
       } else {
         errorMsg = e instanceof ApiError ? e.message : 'Could not open the tailoring workspace.';
-        upgradeUrl = null;
       }
       status = 'error';
     }
@@ -536,9 +529,6 @@
   {:else if status === 'error'}
     <div class="flex min-w-0 flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
       <p class="max-w-md text-sm text-destructive">{errorMsg}</p>
-      {#if upgradeUrl}
-        <Button variant="primary" size="sm" href={upgradeUrl}>Upgrade</Button>
-      {/if}
       <a href={resolve('/jobs/[slug]', { slug })} class="text-sm text-brand hover:underline">Back to the role</a>
     </div>
   {:else}


### PR DESCRIPTION
## Summary
Reverts #2758. Stripe is not moving to live mode yet, and an "Upgrade" button that sends a real visitor to a test-mode Stripe checkout is worse than the plain refusal text it replaced — this pulls it until live payment keys are actually in place.

Clean \`git revert\` of ed7b983d — no other changes.

## Test plan
- [x] \`pnpm check\` (svelte-check) — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Interface**
  - Removed “Upgrade” buttons and pricing links from daily allowance and tailoring error states.
  - Updated blocked-analysis messaging to show allowance usage and reset timing without an upgrade call to action.
  - Tailoring errors now display the server message and, when available, the reset time.
  - Tightened spacing in the daily allowance notice for a more compact presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->