### PR TITLE
Pull minio images from Quay — Docker Hub no longer has them

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,11 @@ services:
   # the previous per-request extraction — real locally, but no upload persists, so the
   # fit analysis never sees a structured résumé. minio-init creates the bucket once and
   # exits; the app waits on that, not on minio itself, since the bucket must exist first.
+  # Pulled from Quay, not Docker Hub: minio/minio and minio/mc no longer exist as Docker
+  # Hub repositories at all (MinIO moved its distribution there), so every pull of the
+  # `minio/*` names 404s — not a rate limit, and not something a retry fixes.
   minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:latest
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
@@ -66,7 +69,7 @@ services:
       - minio_data:/data
 
   minio-init:
-    image: minio/mc:latest
+    image: quay.io/minio/mc:latest
     depends_on:
       - minio
     entrypoint: >


### PR DESCRIPTION
## Summary
\`pr-smoke\` has been failing on every PR for hours, always at the very first \`docker compose up\` step, always on \`minio/minio\` or \`minio/mc\`. This isn't a Docker Hub rate limit: those two repositories no longer exist there at all (\`https://hub.docker.com/v2/repositories/minio/minio/\` returns \`"object not found"\`) — MinIO moved its distribution to Quay.

Fix: pull both from \`quay.io/minio/{minio,mc}:latest\` instead. Same tag, same everything else.

## Test plan
- [x] \`docker compose config --quiet\` — valid
- [x] \`docker pull quay.io/minio/minio:latest\` and \`quay.io/minio/mc:latest\` — both succeed
- [x] \`docker compose up -d minio minio-init\` locally — minio-init's bucket creation succeeds (\`Bucket created successfully \`local/hire-resumes\`\`)
- [ ] \`pr-smoke\` on this PR itself is the real end-to-end proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MinIO service images to use their Quay-hosted sources, ensuring local container setup can continue pulling the required images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->